### PR TITLE
PM API: read field in messages name changed to unread

### DIFF
--- a/imap/message.go
+++ b/imap/message.go
@@ -99,7 +99,7 @@ func hasLabel(msg *protonmail.Message, labelID string) bool {
 // Doesn't support imap.DeletedFlag.
 func fetchFlags(msg *protonmail.Message) []string {
 	var flags []string
-	if msg.IsRead != 0 {
+	if msg.Unread != 1 {
 		flags = append(flags, imap.SeenFlag)
 	}
 	if msg.IsReplied != 0 || msg.IsRepliedAll != 0 {

--- a/protonmail/events.go
+++ b/protonmail/events.go
@@ -51,7 +51,7 @@ type EventMessage struct {
 }
 
 type EventMessageUpdate struct {
-	IsRead       *int
+	Unread       *int
 	Type         *MessageType
 	Time         int64
 	IsReplied    *int
@@ -97,8 +97,8 @@ func (update *EventMessageUpdate) DiffLabelIDs(current []string) (added, removed
 
 func (update *EventMessageUpdate) Patch(msg *Message) {
 	msg.Time = update.Time
-	if update.IsRead != nil {
-		msg.IsRead = *update.IsRead
+	if update.Unread != nil {
+		msg.Unread = *update.Unread
 	}
 	if update.Type != nil {
 		msg.Type = *update.Type

--- a/protonmail/messages.go
+++ b/protonmail/messages.go
@@ -57,7 +57,7 @@ type Message struct {
 	ID             string
 	Order          int64
 	Subject        string
-	IsRead         int
+	Unread         int
 	Type           MessageType
 	Sender         *MessageAddress
 	ReplyTo        *MessageAddress


### PR DESCRIPTION
The field which marked messages as read changed from IsRead to Unread (and flipped the semantics) in API.