### PR TITLE
protonmail: Fix sending messages after API update.

### DIFF
--- a/protonmail/adresses.go
+++ b/protonmail/adresses.go
@@ -31,6 +31,7 @@ type Address struct {
 	Receive     int
 	Status      AddressStatus
 	Type        AddressType
+	Order       int
 	DisplayName string
 	Signature   string // HTML
 	HasKeys     int

--- a/protonmail/messages.go
+++ b/protonmail/messages.go
@@ -565,7 +565,7 @@ type OutgoingMessage struct {
 }
 
 func (c *Client) SendMessage(msg *OutgoingMessage) (sent, parent *Message, err error) {
-	req, err := c.newJSONRequest(http.MethodPost, "/messages/send/"+msg.ID, msg)
+	req, err := c.newJSONRequest(http.MethodPost, "/messages/"+msg.ID, msg)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/protonmail/messages.go
+++ b/protonmail/messages.go
@@ -403,7 +403,7 @@ type MessagePackageSet struct {
 	Body      string // Encrypted body data packet
 
 	// Only if cleartext is sent
-	BodyKey        *MessageBodyKey `json:omitempty`
+	BodyKey        *MessageBodyKey `json:",omitempty"`
 	AttachmentKeys map[string]string
 
 	bodyKey        *packet.EncryptedKey

--- a/protonmail/messages.go
+++ b/protonmail/messages.go
@@ -403,12 +403,17 @@ type MessagePackageSet struct {
 	Body      string // Encrypted body data packet
 
 	// Only if cleartext is sent
-	BodyKey        map[string]string
+	BodyKey        *MessageBodyKey `json:omitempty`
 	AttachmentKeys map[string]string
 
 	bodyKey        *packet.EncryptedKey
 	attachmentKeys map[string]*packet.EncryptedKey
 	signature      int
+}
+
+type MessageBodyKey struct {
+	Algorithm   string
+	Key         string
 }
 
 func NewMessagePackageSet(attachmentKeys map[string]*packet.EncryptedKey) *MessagePackageSet {
@@ -495,9 +500,10 @@ func (set *MessagePackageSet) AddCleartext(addr string) (*MessagePackage, error)
 	set.Type |= MessagePackageCleartext
 
 	if set.BodyKey == nil || set.AttachmentKeys == nil {
-		set.BodyKey = make(map[string]string, 2)
-		set.BodyKey["Algorithm"] = "aes256"
-		set.BodyKey["Key"] = base64.StdEncoding.EncodeToString(set.bodyKey.Key)
+		set.BodyKey = &MessageBodyKey{
+			Algorithm: "aes256",
+			Key: base64.StdEncoding.EncodeToString(set.bodyKey.Key),
+		}
 
 		set.AttachmentKeys = make(map[string]string, len(set.attachmentKeys))
 		for att, key := range set.attachmentKeys {

--- a/protonmail/messages.go
+++ b/protonmail/messages.go
@@ -403,7 +403,7 @@ type MessagePackageSet struct {
 	Body      string // Encrypted body data packet
 
 	// Only if cleartext is sent
-	BodyKey        string
+	BodyKey        map[string]string
 	AttachmentKeys map[string]string
 
 	bodyKey        *packet.EncryptedKey
@@ -494,8 +494,10 @@ func (set *MessagePackageSet) AddCleartext(addr string) (*MessagePackage, error)
 	set.Addresses[addr] = pkg
 	set.Type |= MessagePackageCleartext
 
-	if set.BodyKey == "" || set.AttachmentKeys == nil {
-		set.BodyKey = base64.StdEncoding.EncodeToString(set.bodyKey.Key)
+	if set.BodyKey == nil || set.AttachmentKeys == nil {
+		set.BodyKey = make(map[string]string, 2)
+		set.BodyKey["Algorithm"] = "aes256"
+		set.BodyKey["Key"] = base64.StdEncoding.EncodeToString(set.bodyKey.Key)
 
 		set.AttachmentKeys = make(map[string]string, len(set.attachmentKeys))
 		for att, key := range set.attachmentKeys {

--- a/protonmail/users.go
+++ b/protonmail/users.go
@@ -78,7 +78,7 @@ func (c *Client) GetCurrentUser() (*User, error) {
 		return nil, err
 	}
 
-	req2, err := c.newRequest(http.MethodGet, "/addresses", nil)
+	req, err = c.newRequest(http.MethodGet, "/addresses", nil)
 	if err != nil {
 		return nil, err
 	}
@@ -87,7 +87,7 @@ func (c *Client) GetCurrentUser() (*User, error) {
 		resp
 		Addresses []*Address
 	}
-	if err := c.doJSON(req2, &addrData); err != nil {
+	if err := c.doJSON(req, &addrData); err != nil {
 		return nil, err
 	}
 

--- a/protonmail/users.go
+++ b/protonmail/users.go
@@ -70,13 +70,28 @@ func (c *Client) GetCurrentUser() (*User, error) {
 		return nil, err
 	}
 
-	var respData struct {
+	var userData struct {
 		resp
 		User *User
 	}
-	if err := c.doJSON(req, &respData); err != nil {
+	if err := c.doJSON(req, &userData); err != nil {
 		return nil, err
 	}
 
-	return respData.User, nil
+	req2, err := c.newRequest(http.MethodGet, "/addresses", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var addrData struct {
+		resp
+		Addresses []*Address
+	}
+	if err := c.doJSON(req2, &addrData); err != nil {
+		return nil, err
+	}
+
+	userData.User.Addresses = addrData.Addresses
+
+	return userData.User, nil
 }

--- a/smtp/smtp.go
+++ b/smtp/smtp.go
@@ -95,6 +95,11 @@ func (u *user) Send(from string, to []string, r io.Reader) error {
 		return errors.New("sender address key hasn't been decrypted")
 	}
 
+	senderAddress := &protonmail.MessageAddress{
+		Address:  fromAddr.Email,
+		Name:     fromAddr.DisplayName,
+	}
+
 	msg := &protonmail.Message{
 		ToList:    toPMAddressList(toList),
 		CCList:    toPMAddressList(ccList),
@@ -102,6 +107,7 @@ func (u *user) Send(from string, to []string, r io.Reader) error {
 		Subject:   subject,
 		Header:    formatHeader(mr.Header),
 		AddressID: fromAddr.ID,
+		Sender:    senderAddress,
 	}
 
 	// Create an empty draft


### PR DESCRIPTION
Fixes enough of the protonmail API to send SMTP messages. Not all SMTP-related commands are fixed; for example, UpdateDraftMessage needs message ID added to outermost-level of request. Fixes #20 