### PR TITLE
[README] `hydroxide serve`, not `hydroxide server`

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,8 @@ password (a 32-byte random password generated when logging in).
 
 hydroxide can be used in multiple modes.
 
-> Don't start hydroxide multiple times, instead you can use `hydroxide server`.
+> Don't start hydroxide multiple times, instead you can use `hydroxide serve`.
+> This requires ports 1025 (smtp), 1143 (imap), and 8080 (carddav).
 
 ### SMTP
 


### PR DESCRIPTION
Reference [this commit comment](https://github.com/emersion/hydroxide/commit/6e41a22e6e0630667683b426c2fb8abe7baa1c92#commitcomment-34340322).