### PR TITLE
Update webapp version to 3.16.6

### DIFF
--- a/cmd/hydroxide/hydroxide.go
+++ b/cmd/hydroxide/hydroxide.go
@@ -29,7 +29,7 @@ import (
 func newClient() *protonmail.Client {
 	return &protonmail.Client{
 		RootURL:      "https://mail.protonmail.com/api",
-		AppVersion:   "Web_3.16.2",
+		AppVersion:   "Web_3.16.6",
 	}
 }
 


### PR DESCRIPTION
Hydroxide is failing to communicate with the Protonmail API. I see past issues on the matter 

https://github.com/emersion/hydroxide/issues/36
https://github.com/emersion/hydroxide/issues/62

I'm hoping this pull request helps :)