### PR TITLE
Add hotfix for auth/refresh error 2000 (re-open #71)

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -112,7 +112,8 @@ func EncryptAndSave(auth *CachedAuth, username string, secretKey *[32]byte) erro
 
 func authenticate(c *protonmail.Client, cachedAuth *CachedAuth, username string) (openpgp.EntityList, error) {
 	auth, err := c.AuthRefresh(&cachedAuth.Auth)
-	if apiErr, ok := err.(*protonmail.APIError); ok && apiErr.Code == 10013 {
+	// TODO: error code 2000/2001 'invalid input' happens since 09.2019
+	if apiErr, ok := err.(*protonmail.APIError); ok && (apiErr.Code == 10013 || apiErr.Code == 2000 || apiErr.Code == 2001) {
 		// Invalid refresh token, re-authenticate
 		authInfo, err := c.AuthInfo(username)
 		if err != nil {


### PR DESCRIPTION
Hotfix #70  by re-authenticating on refresh error 2000 to make hydroxide usable again
(Github dows not allow to reopen rebased PR's)