### PR TITLE
Increased MaxSpace int size

### DIFF
--- a/protonmail/users.go
+++ b/protonmail/users.go
@@ -7,7 +7,7 @@ import (
 type User struct {
 	ID         string
 	Name       string
-	UsedSpace  int
+	UsedSpace  int64
 	Currency   string // e.g. EUR
 	Credit     int
 	MaxSpace   int64

--- a/protonmail/users.go
+++ b/protonmail/users.go
@@ -10,7 +10,7 @@ type User struct {
 	UsedSpace  int
 	Currency   string // e.g. EUR
 	Credit     int
-	MaxSpace   int
+	MaxSpace   int64
 	MaxUpload  int
 	Role       int // TODO
 	Private    int


### PR DESCRIPTION
This change prevents errors when python smtplib calls hydroxide. Related: #79 