### PR TITLE
Add attachemt signature support

### DIFF
--- a/imap/message.go
+++ b/imap/message.go
@@ -511,6 +511,11 @@ func createMessage(c *protonmail.Client, u *protonmail.User, privateKeys openpgp
 					return
 				}
 				pw.CloseWithError(cleartext.Close())
+
+				att.Signature, err = cleartext.Signature()
+				if err != nil {
+					log.Printf("no attachment signature available: %v\n", err)
+				}
 			}()
 
 			att, err = c.CreateAttachment(att, pr)

--- a/protonmail/messages.go
+++ b/protonmail/messages.go
@@ -473,15 +473,18 @@ func (set *MessagePackageSet) Encrypt(mimeType string, signed *openpgp.Entity) (
 		if signer.Encrypted {
 			return nil, errors.New("signing key must be decrypted")
 		}
-		set.signature = 1
 	}
 
 	encoded := new(bytes.Buffer)
 	ciphertext := base64.NewEncoder(base64.StdEncoding, encoded)
 
-	cleartext, err := symetricallyEncrypt(ciphertext, key, signer, nil, config)
+	cleartext, err := symmetricallyEncrypt(ciphertext, key, signer, nil, config)
 	if err != nil {
 		return nil, err
+	}
+
+	if signer != nil {
+		set.signature = 1
 	}
 
 	return &outgoingMessageWriter{

--- a/smtp/smtp.go
+++ b/smtp/smtp.go
@@ -237,6 +237,11 @@ func SendMail(c *protonmail.Client, u *protonmail.User, privateKeys openpgp.Enti
 					return
 				}
 				pw.CloseWithError(cleartext.Close())
+
+				att.Signature, err = cleartext.Signature()
+				if err != nil {
+					log.Printf("no attachment signature available: %v\n", err)
+				}
 			}()
 
 			att, err = c.CreateAttachment(att, pr)


### PR DESCRIPTION
Fix error 15197 for encrypted messages with attachments.

Use additional pipe in crypto.symmetricallyEncrypt to pass signature from the
encryption code to the attachment structure as a buffer.

Fixes #31

P.S. I'm not Go developer, so this PR may contain some dirty code. I'm not happy with some solutions myself, especially with signature as buffer, but if I straight away use the same approach as with ContentID or other string fields, Protonmail can't accept this signature and returns Signature: null in POST response.
