### PR TITLE
Refactor auth token refresh to replicate webapp behavior

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -127,6 +127,11 @@ func authenticate(c *protonmail.Client, cachedAuth *CachedAuth, username string)
 		if err != nil {
 			return nil, fmt.Errorf("cannot re-authenticate: %v", err)
 		}
+
+		err = c.AuthCookies(auth)
+		if err != nil {
+			return nil, fmt.Errorf("cannot get cookies: %v", err)
+		}
 	} else if err != nil {
 		return nil, err
 	}

--- a/cmd/hydroxide/main.go
+++ b/cmd/hydroxide/main.go
@@ -31,7 +31,7 @@ var debug bool
 func newClient() *protonmail.Client {
 	return &protonmail.Client{
 		RootURL:    "https://mail.protonmail.com/api",
-		AppVersion: "Web_3.16.6",
+		AppVersion: "Web_3.16.21",
 		Debug:      debug,
 	}
 }
@@ -209,6 +209,11 @@ func main() {
 					log.Fatal(err)
 				}
 				a.Scope = scope
+			}
+
+			err = c.AuthCookies(a)
+			if err != nil {
+				log.Fatal(err)
 			}
 		}
 


### PR DESCRIPTION
Obtain refresh tokens from /auth/cookies and pass them as cookies
in case of refresh.

Initially this branch was intended to fix `invalid refresh token` errors, but by the time of completion you rolled out a simplier fix.

I tried to replicate the way ProtonMailWeb currently works. The steps are following:
1. Obtain `AccessToken` via `/auth` (just like hydroxide does)
2. Send request POST to `/auth/cookies` with [this structure](https://github.com/dvalter/hydroxide/blob/928636e90915241623bfd0e59873d3edf264241d/protonmail/auth.go#L198) with `AccessToken` as `Authorization: Bearer` and obtain `REFRESH-$UID` and `AUTH-$UID` cookies. Response body contains JSON with `Code`, `SessionToken` and `UID` fields; `SessionToken` is identical to `UID`.
3. Regular requests now pass AccessToken inside the `AUTH-$UID` cookie instead of `Authorization: Bearer`.
4. When refresh is required (in HTTP 401 handler in the webapp code), send
POST with `REFRESH-$UID`  cookie, `X-Pm-Uid` header and empty body is sent  to `/auth/refresh`. Response and cookies are identical to `/auth/cookies`

_The most consistent way to make ProtonMailWeb send refresh request is removing `AUTH-$UID` cookie in the browser debugger_

`AUTH-$UID` cookie contains the following JSON:
```json
{
    "AccessToken":"<token>",
    "UID":"<UID>"
}
```
`REFRESH-$UID` cookie contains the following JSON:
```json
{
    "ResponseType":"token",
    "ClientID":"Web",
    "GrantType":"refresh_token",
    "RefreshToken":"<token>",
    "UID":"<UID>",
    "RedirectURI":"https://mail.protonmail.com"
}
```
I doubt it's reasonable to merge this code any time soon, but in case current API stop working, I hope it will help fixing token handling.
Current implementation has one obvious downside: users with TOTP will have to log-in manually after update. However it could be fixed by assembling `REFRESH-$UID` cookie from an existing RefreshToken