### PR TITLE
protonmail: Ignore missing IDs error

### DIFF
--- a/protonmail/protonmail.go
+++ b/protonmail/protonmail.go
@@ -9,6 +9,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"strconv"
+	"strings"
 
 	"golang.org/x/crypto/openpgp"
 
@@ -170,8 +171,12 @@ func (c *Client) doJSON(req *http.Request, respData interface{}) error {
 	if maybeError, ok := respData.(maybeError); ok {
 		if err := maybeError.Err(); err != nil {
 			log.Printf("request failed: %v %v: %v", req.Method, req.URL.String(), err)
-			return err
+
+			if ! strings.Contains(err.Error(), "The IDs is required") {
+				return err
+			}
 		}
 	}
+
 	return nil
 }


### PR DESCRIPTION
This allows tools such as Purelymail's import tool to
function.