### PR TITLE
Use Protonmail fork of golang.org/x/crypto

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,3 +19,5 @@ require (
 	golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae // indirect
 	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 // indirect
 )
+
+replace golang.org/x/crypto => github.com/ProtonMail/crypto v0.0.0-20200605105621-11f6ee2dd602

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,7 @@
+github.com/ProtonMail/crypto v0.0.0-20200416114516-1fa7f403fb9c h1:DAvlgde2Stu18slmjwikiMPs/CKPV35wSvmJS34z0FU=
+github.com/ProtonMail/crypto v0.0.0-20200416114516-1fa7f403fb9c/go.mod h1:Pxr7w4gA2ikI4sWyYwEffm+oew1WAJHzG1SiDpQMkrI=
+github.com/ProtonMail/crypto v0.0.0-20200605105621-11f6ee2dd602 h1:ainph8zAAGO7yqxvgyiZhV/kzDL/l5bXmhePsEuhKSA=
+github.com/ProtonMail/crypto v0.0.0-20200605105621-11f6ee2dd602/go.mod h1:Pxr7w4gA2ikI4sWyYwEffm+oew1WAJHzG1SiDpQMkrI=
 github.com/boltdb/bolt v1.3.1 h1:JQmyP4ZBrce+ZQu0dY660FMfatumYDLun9hBCUVIkF4=
 github.com/boltdb/bolt v1.3.1/go.mod h1:clJnj/oiGkjum5o1McbSZDSLxVThjynRyGBgiAx27Ps=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
@@ -43,11 +47,7 @@ github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
-golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
-golang.org/x/crypto v0.0.0-20200221231518-2aa609cf4a9d h1:1ZiEyfaQIg3Qh0EoqpwAakHVhecoE5wlSg5GjnafJGw=
-golang.org/x/crypto v0.0.0-20200221231518-2aa609cf4a9d/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
-golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae h1:/WDfKMnPU+m5M4xB+6x4kaepxRw6jWvR5iDRdvjHgy8=
 golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/protonmail/contacts.go
+++ b/protonmail/contacts.go
@@ -164,7 +164,7 @@ func (r *detachedSignatureReader) Read(p []byte) (n int, err error) {
 	n, err = r.body.Read(p)
 	if err == io.EOF && !r.eof {
 		// Check signature
-		signer, signatureError := openpgp.CheckArmoredDetachedSignature(r.keyring, &r.signed, r.signature)
+		signer, signatureError := openpgp.CheckArmoredDetachedSignature(r.keyring, &r.signed, r.signature, nil)
 		r.md.IsSigned = true
 		r.md.SignatureError = signatureError
 		if signer != nil {
@@ -190,7 +190,7 @@ func (card *ContactCard) Read(keyring openpgp.KeyRing) (*openpgp.MessageDetails,
 
 		signed := strings.NewReader(card.Data)
 		signature := strings.NewReader(card.Signature)
-		signer, err := openpgp.CheckArmoredDetachedSignature(keyring, signed, signature)
+		signer, err := openpgp.CheckArmoredDetachedSignature(keyring, signed, signature, nil)
 		md.IsSigned = true
 		md.SignatureError = err
 		if signer != nil {

--- a/protonmail/crypto.go
+++ b/protonmail/crypto.go
@@ -36,7 +36,7 @@ func encryptionKey(e *openpgp.Entity, now time.Time) (openpgp.Key, bool) {
 		if subkey.Sig.FlagsValid &&
 			subkey.Sig.FlagEncryptCommunications &&
 			subkey.PublicKey.PubKeyAlgo.CanEncrypt() &&
-			!subkey.Sig.KeyExpired(now) &&
+			!subkey.PublicKey.KeyExpired(subkey.Sig, now) &&
 			(maxTime.IsZero() || subkey.Sig.CreationTime.After(maxTime)) {
 			candidateSubkey = i
 			maxTime = subkey.Sig.CreationTime
@@ -53,7 +53,7 @@ func encryptionKey(e *openpgp.Entity, now time.Time) (openpgp.Key, bool) {
 	// assume that the primary key is ok. Or, if the primary key is
 	// marked as ok to encrypt to, then we can obviously use it.
 	i := primaryIdentity(e)
-	if !i.SelfSignature.FlagsValid || i.SelfSignature.FlagEncryptCommunications && e.PrimaryKey.PubKeyAlgo.CanEncrypt() && !i.SelfSignature.KeyExpired(now) {
+	if !i.SelfSignature.FlagsValid || i.SelfSignature.FlagEncryptCommunications && e.PrimaryKey.PubKeyAlgo.CanEncrypt() && !i.SelfSignature.SigExpired(now) {
 		return openpgp.Key{e, e.PrimaryKey, e.PrivateKey, i.SelfSignature}, true
 	}
 
@@ -70,7 +70,7 @@ func signingKey(e *openpgp.Entity, now time.Time) (openpgp.Key, bool) {
 		if subkey.Sig.FlagsValid &&
 			subkey.Sig.FlagSign &&
 			subkey.PublicKey.PubKeyAlgo.CanSign() &&
-			!subkey.Sig.KeyExpired(now) {
+			!subkey.PublicKey.KeyExpired(subkey.Sig, now) {
 			candidateSubkey = i
 			break
 		}
@@ -84,7 +84,7 @@ func signingKey(e *openpgp.Entity, now time.Time) (openpgp.Key, bool) {
 	// If we have no candidate subkey then we assume that it's ok to sign
 	// with the primary key.
 	i := primaryIdentity(e)
-	if !i.SelfSignature.FlagsValid || i.SelfSignature.FlagSign && !i.SelfSignature.KeyExpired(now) {
+	if !i.SelfSignature.FlagsValid || i.SelfSignature.FlagSign && !i.SelfSignature.SigExpired(now) {
 		return openpgp.Key{e, e.PrimaryKey, e.PrivateKey, i.SelfSignature}, true
 	}
 

--- a/protonmail/srp.go
+++ b/protonmail/srp.go
@@ -8,12 +8,10 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
 	"math/big"
 
 	"golang.org/x/crypto/openpgp"
 	"golang.org/x/crypto/openpgp/clearsign"
-	openpgperrors "golang.org/x/crypto/openpgp/errors"
 )
 
 var randReader io.Reader = rand.Reader
@@ -45,9 +43,8 @@ func decodeModulus(msg string) ([]byte, error) {
 	}
 
 	_, err = openpgp.CheckDetachedSignature(modulusKeyring, bytes.NewReader(block.Bytes), block.ArmoredSignature.Body, nil)
-	if err != nil && err != openpgperrors.ErrUnknownIssuer {
-		//return nil, fmt.Errorf("failed to decode modulus: %v", err)
-		log.Println("warning: failed to check SRP modulus signature:", err)
+	if err != nil {
+		return nil, fmt.Errorf("failed to check modulus signature: %v", err)
 	}
 
 	b, err := base64.StdEncoding.DecodeString(string(block.Plaintext))

--- a/protonmail/srp.go
+++ b/protonmail/srp.go
@@ -1,19 +1,17 @@
 package protonmail
 
 import (
-	"bytes"
 	"crypto/rand"
 	"crypto/subtle"
 	"encoding/base64"
 	"errors"
 	"fmt"
 	"io"
-	"log"
+	// "log"
 	"math/big"
 
-	"golang.org/x/crypto/openpgp"
 	"golang.org/x/crypto/openpgp/clearsign"
-	openpgperrors "golang.org/x/crypto/openpgp/errors"
+	// openpgperrors "golang.org/x/crypto/openpgp/errors"
 )
 
 var randReader io.Reader = rand.Reader
@@ -25,11 +23,12 @@ func decodeModulus(msg string) ([]byte, error) {
 	}
 
 	// TODO: check signature and signature key
-	_, err := openpgp.CheckDetachedSignature(nil, bytes.NewReader(block.Plaintext), block.ArmoredSignature.Body)
-	if err != nil && err != openpgperrors.ErrUnknownIssuer {
+	// FIXME: segfaults
+	// _, err := block.VerifySignature(nil, nil)
+	// if err != nil && err != openpgperrors.ErrUnknownIssuer {
 		//return nil, fmt.Errorf("failed to decode modulus: %v", err)
-		log.Println("warning: failed to check SRP modulus signature:", err)
-	}
+	//	log.Println("warning: failed to check SRP modulus signature:", err)
+	//}
 
 	b, err := base64.StdEncoding.DecodeString(string(block.Plaintext))
 	if err != nil {


### PR DESCRIPTION
The ProtonMail fork of `golang.org/x/crypto` adds support for for ed25519 (termed State-of-the-art by PM) keys. These changes address the breaking changes to the API. According to ProtonMail/crypto#21, there are plans to eventually upstream these, so hopefully we won't have to stick with a fork for long. This library is used by the official bridge, and it is by far the most popular fork and tracks upstream nicely.

Someone who doesn't get `openpgp: unsupported feature: public key algorithm 22` when running `hydroxide auth` should take a look if they get a segfault with the lines below and their corresponding imports uncommented.

https://github.com/BertalanD/hydroxide/blob/287c9b9683e918fd0e8f7cfaf7070ac2d4408cfd/protonmail/srp.go#L27-L31

For the reference, my SRP modulus message was singed by an EDDSA key (ID `0x350585C4E9518F26`) and maybe the algorithm has something to do with the segfault.

Fixes #46 
Fixes #53