### PR TITLE
update usage help to correct flag-command order

### DIFF
--- a/cmd/hydroxide/main.go
+++ b/cmd/hydroxide/main.go
@@ -109,7 +109,7 @@ func listenAndServeCardDAV(addr string, authManager *auth.Manager, eventsManager
 	return s.ListenAndServe()
 }
 
-const usage = `usage: hydroxide <command> <flags>
+const usage = `usage: hydroxide <flags> <command>
 Commands:
 	auth <username>		Login to ProtonMail via hydroxide
 	carddav			Run hydroxide as a CardDAV server


### PR DESCRIPTION
Hi, I had a problem where the suggested usage is not actually how hydroxide was able to parse flags.

Currently, `hydroxide help` claims the correct order is
`usage: hydroxide <command> <flags>`

However, my flags are silently ignored when placing them in that order.
```
# hydroxide serve -smtp-port 2024
2020/07/01 01:43:20 CardDAV server listening on 127.0.0.1:8080
2020/07/01 01:43:20 SMTP server listening on 127.0.0.1:1025
2020/07/01 01:43:20 IMAP server listening on 127.0.0.1:1143
```

So I goofed with it a while and found out that hydroxide will not ignore flags if they go *before* the command.
```
hydroxide -smtp-port 2024 serve
2020/07/01 01:44:12 CardDAV server listening on 127.0.0.1:8080
2020/07/01 01:44:12 SMTP server listening on 127.0.0.1:2024
2020/07/01 01:44:12 IMAP server listening on 127.0.0.1:1143
```

The usage information should be changed to reflect this.