### PR TITLE
Add systemd service files

### DIFF
--- a/services/hydroxide-carddav.service
+++ b/services/hydroxide-carddav.service
@@ -1,0 +1,22 @@
+[Unit]
+Description=Third party ProtonMail CardDAV Bridge
+After=network.target
+
+[Service]
+Type=exec
+User=hydroxide
+Group=hydroxide
+Restart=on-failure
+ExecStart=/usr/bin/hydroxide carddav
+
+ProtectHome=true
+ProtectSystem=full
+PrivateDevices=true
+NoNewPrivileges=true
+PrivateTmp=true
+InaccessibleDirectories=/root /sys /srv -/opt /media -/lost+found
+ReadWriteDirectories=/var/lib/hydroxide
+WorkingDirectory=/var/lib/hydroxide
+
+[Install]
+WantedBy=multi-user.target

--- a/services/hydroxide-imap.service
+++ b/services/hydroxide-imap.service
@@ -1,0 +1,22 @@
+[Unit]
+Description=Third party ProtonMail IMAP Bridge
+After=network.target
+
+[Service]
+Type=exec
+User=hydroxide
+Group=hydroxide
+Restart=on-failure
+ExecStart=/usr/bin/hydroxide imap
+
+ProtectHome=true
+ProtectSystem=full
+PrivateDevices=true
+NoNewPrivileges=true
+PrivateTmp=true
+InaccessibleDirectories=/root /sys /srv -/opt /media -/lost+found
+ReadWriteDirectories=/var/lib/hydroxide
+WorkingDirectory=/var/lib/hydroxide
+
+[Install]
+WantedBy=multi-user.target

--- a/services/hydroxide-smtp.service
+++ b/services/hydroxide-smtp.service
@@ -1,0 +1,22 @@
+[Unit]
+Description=Third party ProtonMail SMTP Bridge
+After=network.target
+
+[Service]
+Type=exec
+User=hydroxide
+Group=hydroxide
+Restart=on-failure
+ExecStart=/usr/bin/hydroxide smtp
+
+ProtectHome=true
+ProtectSystem=full
+PrivateDevices=true
+NoNewPrivileges=true
+PrivateTmp=true
+InaccessibleDirectories=/root /sys /srv -/opt /media -/lost+found
+ReadWriteDirectories=/var/lib/hydroxide
+WorkingDirectory=/var/lib/hydroxide
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Adds systemd service files for IMAP, SMTP, and CardDAV that limits the permissions of hydroxide for security.
Runs the program as user `hydroxide`, group `hydroxide`.
Expects `$HOME` to be at `/var/lib/hydroxide`

Resolves #120.

Feedback welcome on how best to ensure that this user and directory is automatically generated when a package is installed.  We also might want to consider how we could make the setup process more seamless so that users don't have to create the hydroxide user and group, and then run `hydroxide auth` as that user, before running the service.