### PR TITLE
Add Docker container support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,39 @@
 
-FROM golang:1.15.6 AS build
-#1.15.5-alpine3.12
-# docker run -e USERNAME -e PASSWORD -e TOKEN= hydr:latest
-# docker run -it hydr:latest
+# The intention was to stop pulling all these module dependencies every build but Docker doesn't seem to be able to help itself from rebuilding this first stage. May be something I can do in the command line at build time to suggest the local image copy of the finished stage.
+FROM golang:1.15.5-alpine3.12 AS dependencies
 
 ADD . /src
 WORKDIR /src
+RUN go get ./cmd/hydroxide
+
+FROM golang:1.15.5-alpine3.12 AS compilation
+
+COPY --from=dependencies /go /go
+ADD . /src
+WORKDIR /src
+
+# The Go111Module flag doesn't appear to be necessary. Could also separate out the other flags for legibility.
+ENV GO111MODULE=on
 RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o hydroxide ./cmd/hydroxide
 
-FROM alpine:3.12.2 as final
+FROM alpine:3.12.2 as run
+
+LABEL org.opencontainers.image.title="Hydroxide"
+LABEL org.opencontainers.image.description="Containerised version of Hydroxide, the FOSS alternative to ProtonMail's Bridge application. Authenticates and exposes SMTP, IMAP, and CalDAV interfaces."
+LABEL org.opencontainers.image.version="0.2.16"
+LABEL org.opencontainers.image.authors="Ariel@Richtman.com.au;"
+LABEL org.opencontainers.image.source="https://github.com/arichtman/hydroxide"
+
+#TODO: Consider if it's wise to store this. Without token expiry this is pretty dangerous as it negates the security of two factor authentication. I've not checked if it's even possible to explicitly revoke an access token. OTOH it'll make container restarts more reliable as they'll be guaranteed a working access token (more of a concern on kubernetes where restarted pods might be scheduled to a different node)
+VOLUME [ "~/.config/hydroxide" ]
 
 WORKDIR /hydroxide
-COPY --from=build /src/hydroxide .
+COPY --from=compilation /src/hydroxide .
+# NB: Ensure execute permissions on source file or add a RUN chmod step (more wasteful)
 COPY entrypoint.sh .
 
 # SMTP IMAP CalDAV
 EXPOSE 1025 1143 8080
 
-CMD [ "/bin/sh", "-c", "/hydroxide/entrypoint.sh" ]
-# ENTRYPOINT [ "/hydroxide/entrypoint.sh" ]
+# This is some nonsense due to variable substitution and executing commands without shell sessions
+ENTRYPOINT [ "/bin/sh", "-c", "/hydroxide/entrypoint.sh ${USERNAME} ${PASSWORD} ${TOKEN}" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+
+FROM golang:1.15.6 AS build
+#1.15.5-alpine3.12
+# docker run -e USERNAME -e PASSWORD -e TOKEN= hydr:latest
+# docker run -it hydr:latest
+
+ADD . /src
+WORKDIR /src
+RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o hydroxide ./cmd/hydroxide
+
+FROM alpine:3.12.2 as final
+
+WORKDIR /hydroxide
+COPY --from=build /src/hydroxide .
+COPY entrypoint.sh .
+
+# SMTP IMAP CalDAV
+EXPOSE 1025 1143 8080
+
+CMD [ "/bin/sh", "-c", "/hydroxide/entrypoint.sh" ]
+# ENTRYPOINT [ "/hydroxide/entrypoint.sh" ]

--- a/README.md
+++ b/README.md
@@ -97,6 +97,20 @@ For now, it only supports unencrypted local connections.
 hydroxide imap
 ```
 
+## Docker
+
+### Building the image
+
+Image can be built by simply running `docker build .` in the root directory. It's suggested you nominate a `--tag` for convenient use.
+
+### Running the image
+
+On first run the image requires your Protonmail logon, secret, and two factor authentication token. The parameters can be passed in by supplementing the `docker run` command with the environment options `-e USERNAME= -e PASSWORD= -e TOKEN=`. For convenience it's recommended that the volume specified in the container is mapped to a secured directory on the host machine, this ensures that the container will retain a copy of any access tokens it has created in the past.
+
+### Accessing the services
+
+A big warning against simply applying `--network host` and accessing via public internet. This will expose your credentials, as well as any mail contents. If using remotely, consider a reverse proxy or SSH port forwarding for your use case.
+
 ## License
 
 MIT

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+#TODO: Learn to use issues XD
+#TODO: Consider using arguments
+#TODO: Check for empty strings
+#TODO: allow for non-2FA? Seems really insecure as the password would linger in the container. Then again there's no session timeouts on the bridge and the token is stored under ~/.config/hydroxide/auth.json
+
+if [ "${TOKEN}" ]
+then
+  printf "%s\n%s\n" "${PASSWORD}" "${TOKEN}" | ./hydroxide auth $USERNAME
+else
+  printf "\nNo two factor token provided\n"
+  exit 1
+fi;
+
+./hydroxide serve

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,16 +1,33 @@
-#!/bin/sh
+#!/bin/sh -e
 
-#TODO: Learn to use issues XD
-#TODO: Consider using arguments
-#TODO: Check for empty strings
-#TODO: allow for non-2FA? Seems really insecure as the password would linger in the container. Then again there's no session timeouts on the bridge and the token is stored under ~/.config/hydroxide/auth.json
+#TODO: Consider allowing for non-2FA. Seems really insecure as the full credentials would linger in the container. Then again it's hardly secure anyway there's no access token expiry afaik.
+#TODO: Better handling of existing but invalid access tokens. For now we blanket use existing as otherwise container restarts would attempt to auth using stale 2FA token and fail. The downside of this is when we have an expired access token we need to manually remove it to trigger retrieval of a new access token.
 
-if [ "${TOKEN}" ]
-then
-  printf "%s\n%s\n" "${PASSWORD}" "${TOKEN}" | ./hydroxide auth $USERNAME
-else
-  printf "\nNo two factor token provided\n"
-  exit 1
-fi;
+# If access token already exists, simply start serving.
+if [ ! -f ~/.config/hydroxide/auth.json ]; then
+
+  if [ $# -ne 3 ]; then
+    printf "Incorrect argument count.\n"
+    printf "Please provide:\n1) Username\n2) Password\n3) Two factor token\n"
+    exit 1
+  fi
+
+# If token length checks out, attempt authentication for access token creation and storage.
+  if [ ${#3} -eq 6 ]; then
+    printf "%s\n%s\n" "${2}" "${3}" | ./hydroxide auth "${1}"
+
+    if [ $? -ne 0 ]; then
+      printf "Authentication failed. Exiting.\n"
+      exit 2
+    fi
+
+    printf "Authentication successful.\n"
+
+  else
+    printf "Two factor auth token is not the correct length. Exiting.\n"
+    exit 3
+  fi
+
+fi
 
 ./hydroxide serve


### PR DESCRIPTION
Adds:
  - Multi stage Dockerfile to build image
  - Minor additions to `README.md` explaining the Docker portions
  - Wrapper shell script to shim the application into container paradigm

Why?
Can now use Hydroxide anywhere without host OS dependencies, also should work with Kubernetes.

First ever PR, yay!