### PR TITLE
multi-arch docker images

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+.build.yml
+.gitignore
+Dockerfile
+LICENSE
+README.md
+hydroxide

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  # Maintain dependencies for container images
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "daily"
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/workflows/docker_build_push.yml
+++ b/.github/workflows/docker_build_push.yml
@@ -1,0 +1,39 @@
+name: Publish Docker image
+on:
+  push:
+    tags:
+      - "*"
+  pull_request:
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Docker meta
+        id: docker_meta
+        uses: crazy-max/ghaction-docker-meta@v1
+        with:
+          images: ghcr.io/emersion/hydroxide
+          tag-latest: false
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Login to GHCR
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GHCR_ACCESS_TOKEN }}
+      - name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64,linux/arm64,linux/arm/v6,linux/arm/v7
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.docker_meta.outputs.tags }}
+          labels: |
+            ${{ steps.docker_meta.outputs.labels }}

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@
 .glide/
 
 auth.json
+hydroxide

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,25 @@
+FROM --platform=${BUILDPLATFORM:-linux/amd64} golang:1.15.6-buster AS builder
+
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+ARG TARGETOS
+ARG TARGETARCH
+
+ENV GO111MODULE=on
+ENV CGO_ENABLED=0
+ENV GOPATH=/go/src/
+WORKDIR /go/src/github.com/emersion/hydroxide
+COPY go.mod .
+COPY go.sum .
+RUN go mod download
+
+COPY . .
+RUN GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build ./cmd/hydroxide
+
+FROM scratch
+COPY --from=builder /go/src/github.com/emersion/hydroxide/hydroxide /bin/hydroxide
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+ENV XDG_CONFIG_HOME=/home
+USER 1000
+ENTRYPOINT ["/bin/hydroxide"]
+CMD ["serve"]

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/emersion/hydroxide
 
-go 1.13
+go 1.15
 
 require (
 	github.com/boltdb/bolt v1.3.1


### PR DESCRIPTION
Signed-off-by: Noel Georgi <git@frezbo.com>

This PR adds support for building multi-arch docker images and pushing them to GitHub container registry. Also updates the go version to `1.15`

This build and push is using GitHub actions and docker and github actions dependency updates are managed by dependabot. 

In-order for this to work improved container support needs to be enabled as per this (doc)[https://docs.github.com/en/free-pro-team@latest/packages/guides/enabling-improved-container-support] and a repository secret named `GHCR_ACCESS_TOKEN` needs to be created using a personal access token with `package` read/write access scope. I'm glad to answer any queries. I'll keep this PR in draft status until I hear back from the maintainers.