### PR TITLE
Rename Protomail's go-crypto lib to its new goipath

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -9,9 +9,9 @@ import (
 	"io"
 	"os"
 
-	"golang.org/x/crypto/bcrypt"
-	"golang.org/x/crypto/nacl/secretbox"
-	"golang.org/x/crypto/openpgp"
+	"github.com/ProtonMail/go-crypto/bcrypt"
+	"github.com/ProtonMail/go-crypto/nacl/secretbox"
+	"github.com/ProtonMail/go-crypto/openpgp"
 
 	"github.com/emersion/hydroxide/config"
 	"github.com/emersion/hydroxide/protonmail"

--- a/carddav/carddav.go
+++ b/carddav/carddav.go
@@ -12,10 +12,10 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/ProtonMail/go-crypto/openpgp"
 	"github.com/emersion/go-vcard"
 	"github.com/emersion/go-webdav/carddav"
 	"github.com/emersion/hydroxide/protonmail"
-	"golang.org/x/crypto/openpgp"
 )
 
 // TODO: use a HTTP error

--- a/cmd/hydroxide/main.go
+++ b/cmd/hydroxide/main.go
@@ -10,14 +10,14 @@ import (
 	"net/http"
 	"os"
 
+	"github.com/ProtonMail/go-crypto/openpgp"
+	"github.com/ProtonMail/go-crypto/openpgp/armor"
 	imapmove "github.com/emersion/go-imap-move"
 	imapspacialuse "github.com/emersion/go-imap-specialuse"
 	imapserver "github.com/emersion/go-imap/server"
 	"github.com/emersion/go-mbox"
 	"github.com/emersion/go-smtp"
 	"github.com/howeyc/gopass"
-	"golang.org/x/crypto/openpgp"
-	"golang.org/x/crypto/openpgp/armor"
 
 	"github.com/emersion/hydroxide/auth"
 	"github.com/emersion/hydroxide/carddav"

--- a/exports/messages.go
+++ b/exports/messages.go
@@ -6,11 +6,11 @@ import (
 	"io"
 	"strings"
 
+	"github.com/ProtonMail/go-crypto/openpgp"
 	"github.com/emersion/go-mbox"
 	"github.com/emersion/go-message"
 	"github.com/emersion/go-message/mail"
 	"github.com/emersion/go-message/textproto"
-	"golang.org/x/crypto/openpgp"
 
 	"github.com/emersion/hydroxide/protonmail"
 )

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/emersion/hydroxide
 go 1.13
 
 require (
+	github.com/ProtonMail/go-crypto v0.0.0-20201208181130-20fe99622a86
 	github.com/boltdb/bolt v1.3.1
 	github.com/emersion/go-bcrypt v0.0.0-20170822072041-6e724a1baa63
 	github.com/emersion/go-imap v1.0.6
@@ -16,9 +17,6 @@ require (
 	github.com/howeyc/gopass v0.0.0-20190910152052-7cb4b85ec19c
 	github.com/kr/pretty v0.1.0 // indirect
 	github.com/stretchr/testify v1.4.0 // indirect
-	golang.org/x/crypto v0.0.0-20201217014255-9d1352758620
 	golang.org/x/sys v0.0.0-20201214210602-f9fddec55a1e // indirect
 	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 // indirect
 )
-
-replace golang.org/x/crypto => github.com/ProtonMail/crypto v0.0.0-20200605105621-11f6ee2dd602

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/ProtonMail/crypto v0.0.0-20200605105621-11f6ee2dd602 h1:ainph8zAAGO7yqxvgyiZhV/kzDL/l5bXmhePsEuhKSA=
 github.com/ProtonMail/crypto v0.0.0-20200605105621-11f6ee2dd602/go.mod h1:Pxr7w4gA2ikI4sWyYwEffm+oew1WAJHzG1SiDpQMkrI=
+github.com/ProtonMail/go-crypto v0.0.0-20201208181130-20fe99622a86 h1:DzNYdO1Lr0wwznz5wyCGg17N0L+y4Y4QeC/r4nJZbKY=
+github.com/ProtonMail/go-crypto v0.0.0-20201208181130-20fe99622a86/go.mod h1:HTM9X7e9oLwn7RiqLG0UVwVRJenLs3wN+tQ0NPAfwMQ=
 github.com/boltdb/bolt v1.3.1 h1:JQmyP4ZBrce+ZQu0dY660FMfatumYDLun9hBCUVIkF4=
 github.com/boltdb/bolt v1.3.1/go.mod h1:clJnj/oiGkjum5o1McbSZDSLxVThjynRyGBgiAx27Ps=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
@@ -56,10 +58,14 @@ github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
+golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
+golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201214210602-f9fddec55a1e h1:AyodaIpKjppX+cBfTASF2E1US3H2JFBj920Ot3rtDjs=
 golang.org/x/sys v0.0.0-20201214210602-f9fddec55a1e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2 h1:tW2bmiBqwgJj/UpqtC8EpXEZVYOwU0yG4iWbprSVAcs=

--- a/imap/message.go
+++ b/imap/message.go
@@ -8,10 +8,10 @@ import (
 	"log"
 	"strings"
 
+	"github.com/ProtonMail/go-crypto/openpgp"
 	"github.com/emersion/go-imap"
 	"github.com/emersion/go-message"
 	"github.com/emersion/go-message/mail"
-	"golang.org/x/crypto/openpgp"
 
 	"github.com/emersion/hydroxide/protonmail"
 )

--- a/imap/user.go
+++ b/imap/user.go
@@ -5,10 +5,10 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/ProtonMail/go-crypto/openpgp"
 	"github.com/emersion/go-imap"
 	"github.com/emersion/go-imap-specialuse"
 	imapbackend "github.com/emersion/go-imap/backend"
-	"golang.org/x/crypto/openpgp"
 
 	"github.com/emersion/hydroxide/events"
 	"github.com/emersion/hydroxide/imap/database"

--- a/imports/messages.go
+++ b/imports/messages.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/ProtonMail/go-crypto/openpgp"
+	"github.com/ProtonMail/go-crypto/openpgp/armor"
 	"github.com/emersion/go-message/mail"
-	"golang.org/x/crypto/openpgp"
-	"golang.org/x/crypto/openpgp/armor"
 
 	"github.com/emersion/hydroxide/protonmail"
 )

--- a/protonmail/attachments.go
+++ b/protonmail/attachments.go
@@ -11,8 +11,8 @@ import (
 	"strconv"
 	"strings"
 
-	"golang.org/x/crypto/openpgp"
-	"golang.org/x/crypto/openpgp/packet"
+	"github.com/ProtonMail/go-crypto/openpgp"
+	"github.com/ProtonMail/go-crypto/openpgp/packet"
 )
 
 type AttachmentKey struct {

--- a/protonmail/auth.go
+++ b/protonmail/auth.go
@@ -7,8 +7,8 @@ import (
 	"net/http"
 	"time"
 
-	"golang.org/x/crypto/openpgp"
-	"golang.org/x/crypto/openpgp/packet"
+	"github.com/ProtonMail/go-crypto/openpgp"
+	"github.com/ProtonMail/go-crypto/openpgp/packet"
 )
 
 type authInfoReq struct {

--- a/protonmail/contacts.go
+++ b/protonmail/contacts.go
@@ -8,9 +8,9 @@ import (
 	"strconv"
 	"strings"
 
-	"golang.org/x/crypto/openpgp"
-	"golang.org/x/crypto/openpgp/armor"
-	"golang.org/x/crypto/openpgp/packet"
+	"github.com/ProtonMail/go-crypto/openpgp"
+	"github.com/ProtonMail/go-crypto/openpgp/armor"
+	"github.com/ProtonMail/go-crypto/openpgp/packet"
 )
 
 type Contact struct {

--- a/protonmail/crypto.go
+++ b/protonmail/crypto.go
@@ -6,8 +6,8 @@ import (
 	"io"
 	"time"
 
-	"golang.org/x/crypto/openpgp"
-	"golang.org/x/crypto/openpgp/packet"
+	"github.com/ProtonMail/go-crypto/openpgp"
+	"github.com/ProtonMail/go-crypto/openpgp/packet"
 )
 
 // primaryIdentity returns the Identity marked as primary or the first identity

--- a/protonmail/keys.go
+++ b/protonmail/keys.go
@@ -7,7 +7,7 @@ import (
 	"net/url"
 	"strings"
 
-	"golang.org/x/crypto/openpgp"
+	"github.com/ProtonMail/go-crypto/openpgp"
 )
 
 type PrivateKeyFlags int

--- a/protonmail/messages.go
+++ b/protonmail/messages.go
@@ -10,9 +10,9 @@ import (
 	"strconv"
 	"strings"
 
-	"golang.org/x/crypto/openpgp"
-	"golang.org/x/crypto/openpgp/armor"
-	"golang.org/x/crypto/openpgp/packet"
+	"github.com/ProtonMail/go-crypto/openpgp"
+	"github.com/ProtonMail/go-crypto/openpgp/armor"
+	"github.com/ProtonMail/go-crypto/openpgp/packet"
 )
 
 type MessageType int

--- a/protonmail/protonmail.go
+++ b/protonmail/protonmail.go
@@ -11,7 +11,7 @@ import (
 	"strconv"
 	"time"
 
-	"golang.org/x/crypto/openpgp"
+	"github.com/ProtonMail/go-crypto/openpgp"
 
 	"log"
 )

--- a/protonmail/srp.go
+++ b/protonmail/srp.go
@@ -10,8 +10,8 @@ import (
 	"io"
 	"math/big"
 
-	"golang.org/x/crypto/openpgp"
-	"golang.org/x/crypto/openpgp/clearsign"
+	"github.com/ProtonMail/go-crypto/openpgp"
+	"github.com/ProtonMail/go-crypto/openpgp/clearsign"
 )
 
 var randReader io.Reader = rand.Reader

--- a/smtp/smtp.go
+++ b/smtp/smtp.go
@@ -8,10 +8,10 @@ import (
 	"log"
 	"strings"
 
+	"github.com/ProtonMail/go-crypto/openpgp"
+	"github.com/ProtonMail/go-crypto/openpgp/packet"
 	"github.com/emersion/go-message/mail"
 	"github.com/emersion/go-smtp"
-	"golang.org/x/crypto/openpgp"
-	"golang.org/x/crypto/openpgp/packet"
 
 	"github.com/emersion/hydroxide/auth"
 	"github.com/emersion/hydroxide/protonmail"


### PR DESCRIPTION
Protonmail's patched crypto lib has been renamed to `github.com/ProtonMail/go-crypto` and can be directly referred. This patch replaces the indirect reference which also solves a packaging issue on Fedora.