### PR TITLE
Add angled brackets around Message-Id header

### DIFF
--- a/imap/message.go
+++ b/imap/message.go
@@ -227,7 +227,7 @@ func messageHeader(msg *protonmail.Message) message.Header {
 		h.SetAddressList("Bcc", mailAddressList(msg.BCCList))
 	}
 	// TODO: In-Reply-To
-	h.Set("Message-Id", messageID(msg))
+	h.Set("Message-Id", fmt.Sprintf("<%s>", messageID(msg)))
 	return h.Header
 }
 


### PR DESCRIPTION
From: [RFC 2392 section 2](https://tools.ietf.org/html/rfc2392#section-2)

> In Internet mail messages, the addr-spec in a Content-ID
     [MIME] or Message-ID [822] header is enclosed in angle brackets
     (<>).

For example:
```
Message-Id: <abc@example.com>
```
hydroxide was doing this instead:
```
Message-Id: abc@example.com
```

I noticed this because I have my mail stored offline, and found that not having these angled brackets in the mail files causes utilities such as `notmuch` to not behave correctly