### PR TITLE
Fix for #142

### DIFF
--- a/imap/message.go
+++ b/imap/message.go
@@ -237,6 +237,12 @@ func (mbox *mailbox) fetchBodySection(msg *protonmail.Message, section *imap.Bod
 	b := new(bytes.Buffer)
 
 	if len(section.Path) == 0 {
+		// Need to get full message so that ReplyTos are fetched
+		msg, err := mbox.u.c.GetMessage(msg.ID)
+		if err != nil {
+			return nil, err
+		}
+
 		w, err := message.CreateWriter(b, messageHeader(msg))
 		if err != nil {
 			return nil, err
@@ -248,11 +254,6 @@ func (mbox *mailbox) fetchBodySection(msg *protonmail.Message, section *imap.Bod
 
 		switch section.Specifier {
 		case imap.EntireSpecifier, imap.TextSpecifier:
-			msg, err := mbox.u.c.GetMessage(msg.ID)
-			if err != nil {
-				return nil, err
-			}
-
 			pw, err := w.CreatePart(inlineHeader(msg))
 			if err != nil {
 				return nil, err


### PR DESCRIPTION
This fixes #142

Basically all that needed to be done was in the fetchBodySection method we had to use the headers from the *entire fetched message* rather than from the one passed to the function.
 
This is because ProtonMail's API for listing messages (`/messages/<filter>...`) does not seem to allow for listing messages with their ReplyTos field included - the field can only be retrieved with the entire message. The message given to fetchBodySection is retrieved using ListMessages, and thus is missing the ReplyTos header

Please let me know if I did this properly or not :laughing: 