### PR TITLE
new: add support for tls

### DIFF
--- a/cmd/hydroxide/main.go
+++ b/cmd/hydroxide/main.go
@@ -46,7 +46,7 @@ func listenAndServeSMTP(addr string, debug bool, authManager *auth.Manager, tlsC
 	s := smtp.NewServer(be)
 	s.Addr = addr
 	s.Domain = "localhost" // TODO: make this configurable
-	// s.AllowInsecureAuth = true // TODO: remove this
+	s.AllowInsecureAuth = tlsConfig == nil
 	s.TLSConfig = tlsConfig
 	if debug {
 		s.Debug = os.Stdout
@@ -65,7 +65,7 @@ func listenAndServeIMAP(addr string, debug bool, authManager *auth.Manager, even
 	be := imapbackend.New(authManager, eventsManager)
 	s := imapserver.New(be)
 	s.Addr = addr
-	// s.AllowInsecureAuth = true // TODO: remove this
+	s.AllowInsecureAuth = tlsConfig == nil
 	s.TLSConfig = tlsConfig
 	if debug {
 		s.Debug = os.Stdout

--- a/config/tls.go
+++ b/config/tls.go
@@ -1,0 +1,49 @@
+package config
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"io/ioutil"
+)
+
+func TLS(certPath string, keyPath string, clientCAPath string) (*tls.Config, error) {
+
+	tlsConfig := &tls.Config{}
+
+	if certPath != "" && keyPath != "" {
+
+		certData, err := ioutil.ReadFile(certPath)
+		if err != nil {
+			return nil, fmt.Errorf("error: unable read certificate: %s", err)
+		}
+
+		keyData, err := ioutil.ReadFile(keyPath)
+		if err != nil {
+			return nil, fmt.Errorf("error: unable read key: %s", err)
+		}
+
+		cert, err := tls.X509KeyPair(certData, keyData)
+		if err != nil {
+			return nil, fmt.Errorf("error: unable load key pair: %s", err)
+		}
+
+		tlsConfig.Certificates = []tls.Certificate{cert}
+	}
+
+	if clientCAPath != "" {
+
+		data, err := ioutil.ReadFile(clientCAPath)
+		if err != nil {
+			return nil, fmt.Errorf("error: unable read CA file: %s", err)
+		}
+
+		pool := x509.NewCertPool()
+		pool.AppendCertsFromPEM(data)
+
+		tlsConfig.ClientCAs = pool
+		tlsConfig.ClientAuth = tls.RequireAndVerifyClientCert
+	}
+
+	return tlsConfig, nil
+}

--- a/config/tls.go
+++ b/config/tls.go
@@ -8,22 +8,10 @@ import (
 )
 
 func TLS(certPath string, keyPath string, clientCAPath string) (*tls.Config, error) {
-
 	tlsConfig := &tls.Config{}
 
 	if certPath != "" && keyPath != "" {
-
-		certData, err := ioutil.ReadFile(certPath)
-		if err != nil {
-			return nil, fmt.Errorf("error: unable read certificate: %s", err)
-		}
-
-		keyData, err := ioutil.ReadFile(keyPath)
-		if err != nil {
-			return nil, fmt.Errorf("error: unable read key: %s", err)
-		}
-
-		cert, err := tls.X509KeyPair(certData, keyData)
+		cert, err := tls.LoadX509KeyPair(certPath, keyPath)
 		if err != nil {
 			return nil, fmt.Errorf("error: unable load key pair: %s", err)
 		}
@@ -32,7 +20,6 @@ func TLS(certPath string, keyPath string, clientCAPath string) (*tls.Config, err
 	}
 
 	if clientCAPath != "" {
-
 		data, err := ioutil.ReadFile(clientCAPath)
 		if err != nil {
 			return nil, fmt.Errorf("error: unable read CA file: %s", err)


### PR DESCRIPTION
Support for `-tls-cert` and `-tls-key` to point to a certificate and
a key to encrypt communications between the user and hydroxide.

Support for `-tls-client-ca` to ask client to present a certificate
signed by the provided CA.