### PR TITLE
Fixes #165 unhandled charset utf8

### DIFF
--- a/smtp/smtp.go
+++ b/smtp/smtp.go
@@ -17,6 +17,8 @@ import (
 	"github.com/emersion/hydroxide/protonmail"
 )
 
+import _ "github.com/emersion/go-message/charset"
+
 func toPMAddressList(addresses []*mail.Address) []*protonmail.MessageAddress {
 	l := make([]*protonmail.MessageAddress, len(addresses))
 	for i, addr := range addresses {


### PR DESCRIPTION
Fixes #165 
According to the [go-message README](https://github.com/emersion/go-message/blob/3fb0148294d18c22fa581c2f2eee441d60ca19e4/README.md) in order to start using all charset encodings, we simply have to import this package.

If we're trying to keep things light, alternatively, we could just add an extra if statement in go-message charset.go
```go
func charsetReader(charset string, input io.Reader) (io.Reader, error) {
  charset = strings.ToLower(charset)
  if charset == "utf-8" || charset == "utf8"  || charset == "us-ascii"{
  return input, nil
}
```