### PR TITLE
Fix for `[9001] Login temporarily not permitted` error

### DIFF
--- a/cmd/hydroxide/main.go
+++ b/cmd/hydroxide/main.go
@@ -35,8 +35,8 @@ var debug bool
 
 func newClient() *protonmail.Client {
 	return &protonmail.Client{
-		RootURL:    "https://mail.protonmail.com/api",
-		AppVersion: "Web_3.16.6",
+		RootURL:    "https://old.protonmail.com/api",
+		AppVersion: "Web_3.16.65",
 		Debug:      debug,
 	}
 }


### PR DESCRIPTION
fixes #181