### PR TITLE
Allows running hydroxide over I2P

### DIFF
--- a/cmd/hydroxide/main.go
+++ b/cmd/hydroxide/main.go
@@ -221,6 +221,8 @@ Global options:
 		SMTP port on which hydroxide listens, defaults to 1025
 	-imap-port example.com
 		IMAP port on which hydroxide listens, defaults to 1143
+	-i2p example
+		Listen as an I2P service. Keys will be generated for you and placed in the working directory at example-dav, example-smtp, example-imap.
 	-carddav-port example.com
 		CardDAV port on which hydroxide listens, defaults to 8080
 	-disable-imap
@@ -266,9 +268,9 @@ func main() {
 	exportMessagesCmd := flag.NewFlagSet("export-messages", flag.ExitOnError)
 	sendmailCmd := flag.NewFlagSet("sendmail", flag.ExitOnError)
 
-	//flag.Usage = func() {
-	//	fmt.Print(usage)
-	//}
+	flag.Usage = func() {
+		fmt.Print(usage)
+	}
 
 	flag.Parse()
 

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/emersion/go-smtp v0.15.0
 	github.com/emersion/go-vcard v0.0.0-20210521075357-3445b9171995
 	github.com/emersion/go-webdav v0.3.1
+	github.com/eyedeekay/sam3 v0.32.32 // indirect
 	github.com/mattn/go-isatty v0.0.14
 	golang.org/x/crypto v0.0.0-20211117183948-ae814b36b871
 	golang.org/x/sys v0.0.0-20211117180635-dee7805ff2e1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -27,6 +27,8 @@ github.com/emersion/go-vcard v0.0.0-20210521075357-3445b9171995 h1:DpVfmcoBs6o9V
 github.com/emersion/go-vcard v0.0.0-20210521075357-3445b9171995/go.mod h1:HMJKR5wlh/ziNp+sHEDV2ltblO4JD2+IdDOWtGcQBTM=
 github.com/emersion/go-webdav v0.3.1 h1:8ISu6AlBwu7DKg9RQE3iRpE3CPM8Bfpfz7L3bi/xlGI=
 github.com/emersion/go-webdav v0.3.1/go.mod h1:uSM1VveeKtogBVWaYccTksToczooJ0rrVGNsgnDsr4Q=
+github.com/eyedeekay/sam3 v0.32.32 h1:9Ea1Ere5O8Clx8zYxKnvhrWy7R96Q4FvxlPskYf8VW0=
+github.com/eyedeekay/sam3 v0.32.32/go.mod h1:qRA9KIIVxbrHlkj+ZB+OoxFGFgdKeGp1vSgPw26eOVU=
 github.com/mattn/go-isatty v0.0.14 h1:yVuAays6BHfxijgZPzw+3Zlu5yQgKGP2/hcQbHb7S9Y=
 github.com/mattn/go-isatty v0.0.14/go.mod h1:7GGIvUiUoEMVVmxf/4nioHXj79iQHKdU27kJ6hsGG94=
 golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2/go.mod h1:T9bdIzuCu7OtxOm1hfPfRQxPLYneinmdGuTeoZ9dtd4=


### PR DESCRIPTION
This adds support for connecting to ProtonMail services over the I2P anonymity network. The use case is for people who want to "Trust" a ProtonMail bridge on a server somewhere in a safe location, while they use I2P to retrieve their messages from an unsafe location without revealing information to network observers. I2P is only activated if a string is passed to the -i2p flag, and the name and location of the I2P keys is decided based on the string. The support itself couldn't be simpler, it's just a listener being passed to the respective server. I'd like to add it here rather than trying to maintain a fork, it shouldn't require any maintenance on your part except occasionally updating the module.