### PR TITLE
Fix issue #149

### DIFF
--- a/imap/mailbox.go
+++ b/imap/mailbox.go
@@ -308,9 +308,9 @@ func (mbox *mailbox) SearchMessages(isUID bool, c *imap.SearchCriteria) ([]uint3
 	}
 
 	// TODO: c.Not, c.Or
-	if c.Not != nil || c.Or != nil {
-		return nil, errors.New("search queries with NOT or OR clauses are not yet implemented")
-	}
+	// if c.Not != nil || c.Or != nil {
+	// 	return nil, errors.New("search queries with NOT or OR clauses are not yet implemented")
+	// }
 
 	var results []uint32
 	err := mbox.db.ForEach(func(seqNum, uid uint32, apiID string) error {


### PR DESCRIPTION
I've fixed issue #149 by commenting out lines 311 to 313 of imap/mailbox.go. This obviously doesn't add the functionality, but prevents K-9 Mail from interpreting the output as an error, upon which the application fetches all mail with absolutely no issue.