### PR TITLE
Fix Error Code 9001 / "Login temporarily not permitted from your connection for security reasons"

### DIFF
--- a/cmd/hydroxide/main.go
+++ b/cmd/hydroxide/main.go
@@ -32,7 +32,7 @@ import (
 	smtpbackend "github.com/emersion/hydroxide/smtp"
 )
 
-const defaultAPIEndpoint = "https://mail.protonmail.com/api"
+const defaultAPIEndpoint = "https://mail.proton.me/api"
 
 var (
 	debug       bool
@@ -42,7 +42,7 @@ var (
 func newClient() *protonmail.Client {
 	return &protonmail.Client{
 		RootURL:    apiEndpoint,
-		AppVersion: "web-mail@4.20.8",
+		AppVersion: "web-mail@5.0.2.3",
 		Debug:      debug,
 	}
 }

--- a/protonmail/protonmail.go
+++ b/protonmail/protonmail.go
@@ -119,6 +119,7 @@ func (c *Client) newJSONRequest(method, path string, body interface{}) (*http.Re
 }
 
 func (c *Client) do(req *http.Request) (*http.Response, error) {
+	req.Header.Set("User-Agent","Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/102.0.0.0 Safari/537.36")
 	httpClient := c.HTTPClient
 	if httpClient == nil {
 		httpClient = http.DefaultClient
@@ -154,7 +155,6 @@ func (c *Client) do(req *http.Request) (*http.Response, error) {
 
 func (c *Client) doJSON(req *http.Request, respData interface{}) error {
 	req.Header.Set("Accept", "application/json")
-	req.Header.Set("User-Agent","Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/102.0.0.0 Safari/537.36")
 	if respData == nil {
 		respData = new(resp)
 	}

--- a/protonmail/protonmail.go
+++ b/protonmail/protonmail.go
@@ -154,7 +154,7 @@ func (c *Client) do(req *http.Request) (*http.Response, error) {
 
 func (c *Client) doJSON(req *http.Request, respData interface{}) error {
 	req.Header.Set("Accept", "application/json")
-
+	req.Header.Set("User-Agent","Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/102.0.0.0 Safari/537.36")
 	if respData == nil {
 		respData = new(resp)
 	}


### PR DESCRIPTION
Adds the latest version number, new API URL and a recent Chrome user agent to help avoid 9001 [Login temporarily not permitted from your connection for security reasons] issues.