### PR TITLE
Remove deprecated IMAP extension dependencies

### DIFF
--- a/cmd/hydroxide/main.go
+++ b/cmd/hydroxide/main.go
@@ -13,8 +13,6 @@ import (
 
 	"github.com/ProtonMail/go-crypto/openpgp"
 	"github.com/ProtonMail/go-crypto/openpgp/armor"
-	imapmove "github.com/emersion/go-imap-move"
-	imapspacialuse "github.com/emersion/go-imap-specialuse"
 	imapserver "github.com/emersion/go-imap/server"
 	"github.com/emersion/go-mbox"
 	"github.com/emersion/go-smtp"
@@ -103,9 +101,6 @@ func listenAndServeIMAP(addr string, debug bool, authManager *auth.Manager, even
 	if debug {
 		s.Debug = os.Stdout
 	}
-
-	s.Enable(imapspacialuse.NewExtension())
-	s.Enable(imapmove.NewExtension())
 
 	if s.TLSConfig != nil {
 		log.Println("IMAP server listening with TLS on", s.Addr)

--- a/go.mod
+++ b/go.mod
@@ -7,8 +7,6 @@ require (
 	github.com/boltdb/bolt v1.3.1
 	github.com/emersion/go-bcrypt v0.0.0-20170822072041-6e724a1baa63
 	github.com/emersion/go-imap v1.2.1
-	github.com/emersion/go-imap-move v0.0.0-20210907172020-fe4558f9c872
-	github.com/emersion/go-imap-specialuse v0.0.0-20201101201809-1ab93d3d150e
 	github.com/emersion/go-mbox v1.0.2
 	github.com/emersion/go-message v0.15.0
 	github.com/emersion/go-sasl v0.0.0-20211008083017-0b9dcfb154ac // indirect

--- a/go.sum
+++ b/go.sum
@@ -7,10 +7,6 @@ github.com/emersion/go-bcrypt v0.0.0-20170822072041-6e724a1baa63/go.mod h1:eRwwJ
 github.com/emersion/go-ical v0.0.0-20200224201310-cd514449c39e/go.mod h1:4xVTBPcT43a1pp3vdaa+FuRdX5XhKCZPpWv7m0z9ByM=
 github.com/emersion/go-imap v1.2.1 h1:+s9ZjMEjOB8NzZMVTM3cCenz2JrQIGGo5j1df19WjTA=
 github.com/emersion/go-imap v1.2.1/go.mod h1:Qlx1FSx2FTxjnjWpIlVNEuX+ylerZQNFE5NsmKFSejY=
-github.com/emersion/go-imap-move v0.0.0-20210907172020-fe4558f9c872 h1:HGBfonz0q/zq7y3ew+4oy4emHSvk6bkmV0mdDG3E77M=
-github.com/emersion/go-imap-move v0.0.0-20210907172020-fe4558f9c872/go.mod h1:QuMaZcKFDVI0yCrnAbPLfbwllz1wtOrZH8/vZ5yzp4w=
-github.com/emersion/go-imap-specialuse v0.0.0-20201101201809-1ab93d3d150e h1:AwVkRMFFUMNu+tx0jchwyoXhS2VClQSzTtByVuzxbsE=
-github.com/emersion/go-imap-specialuse v0.0.0-20201101201809-1ab93d3d150e/go.mod h1:/nybxhI8kXom8Tw6BrHMl42usALvka6meORflnnYwe4=
 github.com/emersion/go-mbox v1.0.2 h1:tE/rT+lEugK9y0myEymCCHnwlZN04hlXPrbKkxRBA5I=
 github.com/emersion/go-mbox v1.0.2/go.mod h1:Yp9IVuuOYLEuMv4yjgDHvhb5mHOcYH6x92Oas3QqEZI=
 github.com/emersion/go-message v0.15.0 h1:urgKGqt2JAc9NFJcgncQcohHdiYb803YTH9OQwHBHIY=

--- a/imap/user.go
+++ b/imap/user.go
@@ -7,9 +7,7 @@ import (
 
 	"github.com/ProtonMail/go-crypto/openpgp"
 	"github.com/emersion/go-imap"
-	"github.com/emersion/go-imap-specialuse"
 	imapbackend "github.com/emersion/go-imap/backend"
-
 	"github.com/emersion/hydroxide/events"
 	"github.com/emersion/hydroxide/imap/database"
 	"github.com/emersion/hydroxide/protonmail"
@@ -21,13 +19,13 @@ var systemMailboxes = []struct {
 	attrs []string
 }{
 	{imap.InboxName, protonmail.LabelInbox, nil},
-	{"All Mail", protonmail.LabelAllMail, []string{specialuse.All}},
-	{"Archive", protonmail.LabelArchive, []string{specialuse.Archive}},
-	{"Drafts", protonmail.LabelDraft, []string{specialuse.Drafts}},
-	{"Starred", protonmail.LabelStarred, []string{specialuse.Flagged}},
-	{"Spam", protonmail.LabelSpam, []string{specialuse.Junk}},
-	{"Sent", protonmail.LabelSent, []string{specialuse.Sent}},
-	{"Trash", protonmail.LabelTrash, []string{specialuse.Trash}},
+	{"All Mail", protonmail.LabelAllMail, []string{imap.AllAttr}},
+	{"Archive", protonmail.LabelArchive, []string{imap.ArchiveAttr}},
+	{"Drafts", protonmail.LabelDraft, []string{imap.DraftsAttr}},
+	{"Starred", protonmail.LabelStarred, []string{imap.FlaggedAttr}},
+	{"Spam", protonmail.LabelSpam, []string{imap.JunkAttr}},
+	{"Sent", protonmail.LabelSent, []string{imap.SentAttr}},
+	{"Trash", protonmail.LabelTrash, []string{imap.TrashAttr}},
 }
 
 var systemFlags = []struct {


### PR DESCRIPTION
Hey! I'm packaging Hydroxide for Guix, and I noticed that `go-imap-move` and `go-imap-specialuse` have both been merged into `go-imap`. In order to avoid packaging the outdated extensions as dependencies, I've attempted to remove them. I'm not a Go developer, so I'm wary that what I intend might not be as simple as what I'm submitting, but it builds and runs (so far) without issue.

If anyone would like to correct my ignorance, that'd be great. Otherwise, I hope this PR can be merged soon. :crossed_fingers: