### PR TITLE
Fix [9001] error upon login

### DIFF
--- a/protonmail/protonmail.go
+++ b/protonmail/protonmail.go
@@ -119,7 +119,9 @@ func (c *Client) newJSONRequest(method, path string, body interface{}) (*http.Re
 }
 
 func (c *Client) do(req *http.Request) (*http.Response, error) {
-	req.Header.Set("User-Agent", "Mozilla/5.0 (X11; Linux x86_64; rv:101.0) Gecko/20100101 Firefox/101.0")
+	// See https://github.com/ProtonMail/proton-python-client/blob/547abc8fc9a58f2d1076e9a559e12ede0d50f47e/proton/api.py#L168
+	req.Header.Set("User-Agent", "Ubuntu_20.04")
+	req.Header.Set("x-pm-appversion", "Other")
 
 	httpClient := c.HTTPClient
 	if httpClient == nil {


### PR DESCRIPTION
This pull request fixes #179. I skimmed through [proton-python-client](https://github.com/ProtonMail/proton-python-client) and it seems that `User-Agent` and `x-pm-appversion` is needed for login to work.

I tried this on two different protonmail accounts on two different IPs and login works for me.