### PR TITLE
Fix 2FA login with both TOTP and U2F enabled

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -134,7 +134,7 @@ func authenticate(c *protonmail.Client, cachedAuth *CachedAuth, username string)
 			return nil, fmt.Errorf("cannot re-authenticate: %v", err)
 		}
 
-		if auth.TwoFactor.Enabled == 1 {
+		if auth.TwoFactor.Enabled != 0 {
 			return nil, fmt.Errorf("cannot re-authenticate: two factor authentication enabled, please login again manually")
 		}
 	} else if err != nil {

--- a/cmd/hydroxide/main.go
+++ b/cmd/hydroxide/main.go
@@ -291,7 +291,7 @@ func main() {
 				log.Fatal(err)
 			}
 
-			if a.TwoFactor.Enabled == 1 {
+			if a.TwoFactor.Enabled != 0 {
 				if a.TwoFactor.TOTP != 1 {
 					log.Fatal("Only TOTP is supported as a 2FA method")
 				}


### PR DESCRIPTION
The `2FA.Enabled` field in `/auth`'s JSON output seems to be a bitmap of some sort, as the API returns `3` when both TOTP and U2F login is on. This commit changes some `Enabled == 1` checks to `Enabled != 0` to handle this case properly.

Fixes #250