### PR TITLE
added subfolder support

### DIFF
--- a/imap/user.go
+++ b/imap/user.go
@@ -177,7 +177,13 @@ func (u *user) initMailboxes() error {
 				continue
 			}
 
-			u.mailboxes[label.ID], err = newMailbox(label.Name, label.ID, nil, u)
+      var displayName string
+      if len(label.Path) > 0 {
+        displayName = strings.ReplaceAll(label.Path, "/", ".")
+      } else {
+        displayName = label.Name
+      }
+			u.mailboxes[label.ID], err = newMailbox(displayName, label.ID, nil, u)
 			if err != nil {
 				return err
 			}

--- a/protonmail/labels.go
+++ b/protonmail/labels.go
@@ -27,6 +27,7 @@ const (
 type Label struct {
 	ID        string
 	Name      string
+  Path      string
 	Color     string
 	Display   int
 	Type      LabelType


### PR DESCRIPTION
Protonmail provides a label metadata field `path` which includes the full path of the folder. This commit adds support for path and uses path if it exists, thus preventing the situation where folder `x/z` appears to be the same as folder `y/z`. It then converts the slashes in the paths to dots when presented to the IMAP client. A better implementation would use the IMAP RFC to show parent and child folders and shouldn't be too hard to do, but this at least allows the user to see their fully qualified folders in their IMAP client for the time being, rather than having an erroneous presentation.