### PR TITLE
Added nested folder support and TLS support with automated certificate generation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,10 +59,21 @@ go build ./cmd/hydroxide
 
 # Run all services together
 ./hydroxide serve
+
+# Run with TLS support
+./hydroxide -tls-auto-generate serve              # Auto-generate certificates
+./hydroxide -tls-cert cert.pem -tls-key key.pem serve   # Use custom certificates
+./hydroxide -tls-cert cert.pem -tls-key key.pem -imap-tls-mode implicit imap
 ```
 
 ### Environment Variables
 - `HYDROXIDE_BRIDGE_PASS`: Skip bridge password prompt
+
+### TLS Certificate Management
+- Auto-generated certificates: `--tls-auto-generate` flag creates self-signed certs in config directory
+- Custom certificates: Use `--tls-cert` and `--tls-key` for production deployments
+- Certificate storage: `~/.config/hydroxide/` (Linux/macOS) or `%APPDATA%\hydroxide\` (Windows)
+- Certificate properties: RSA 2048-bit, 1-year validity, localhost + 127.0.0.1 SAN
 
 ### Common Operations
 ```bash
@@ -93,6 +104,9 @@ go build ./cmd/hydroxide
   - ProtonMail Bridge-compatible folder structure (Folders/ and Labels/)
   - Proper IMAP RFC 3501 compliance for mbsync/isync compatibility
   - Custom JSON unmarshaling for flexible API response handling
+  - Complete TLS support: STARTTLS and implicit TLS (IMAPS) modes
+  - Automatic self-signed certificate generation for easy setup
+  - Client certificate authentication with CA verification
 
 ## Dependencies
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,118 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+Hydroxide is a third-party, open-source ProtonMail bridge designed for headless server environments. It translates standard email protocols (SMTP, IMAP, CardDAV) into ProtonMail API requests, allowing users to access ProtonMail with standard email clients.
+
+## Architecture
+
+### Core Components
+
+- **protonmail/**: ProtonMail API client implementation
+  - Main client in `protonmail.go` with API version 3
+  - Handles authentication, messages, contacts, attachments, encryption
+  - Uses OpenPGP for cryptographic operations
+  - Label struct supports nested folder hierarchy via ParentID and Path fields
+
+- **auth/**: Authentication and credential management
+  - Manages bridge passwords and encrypted credential storage
+  - Handles ProtonMail login, 2FA, and session management
+
+- **imap/**: IMAP server implementation
+  - Backend in `backend.go` implements go-imap interfaces
+  - Database layer for mailbox and user management
+  - **Full nested folder support** with ProtonMail Bridge-compatible structure
+  - Proper distinction between Folders (exclusive) and Labels (non-exclusive)
+  - IMAP RFC 3501 compliant folder attributes (HasChildren/HasNoChildren)
+
+- **smtp/**: SMTP server implementation
+  - Handles outgoing email through ProtonMail API
+  - Supports sendmail interface
+
+- **carddav/**: CardDAV server for contacts
+  - Requires HTTPS reverse proxy in production
+  - Tested with GNOME Evolution and Android DAVDroid
+
+- **events/**: Real-time event management
+  - Handles ProtonMail API events for synchronization
+
+- **config/**: Configuration and TLS management
+
+## Development Commands
+
+### Building
+```bash
+go build ./cmd/hydroxide
+```
+
+### Running
+```bash
+# Authenticate with ProtonMail
+./hydroxide auth <username>
+
+# Run individual services
+./hydroxide smtp    # Port 1025
+./hydroxide imap    # Port 1143 (work-in-progress)
+./hydroxide carddav # Port 8080
+
+# Run all services together
+./hydroxide serve
+```
+
+### Environment Variables
+- `HYDROXIDE_BRIDGE_PASS`: Skip bridge password prompt
+
+### Common Operations
+```bash
+# Check authentication status
+./hydroxide status
+
+# Export secret keys
+./hydroxide export-secret-keys <username>
+
+# Import/export messages
+./hydroxide import-messages <username> [file]
+./hydroxide export-messages -message-id <id> <username>
+
+# Sendmail interface
+./hydroxide sendmail <username> -- <args...>
+```
+
+## Key Technical Details
+
+- **Language**: Go 1.23.8
+- **Database**: BoltDB (bbolt) for local storage
+- **Encryption**: ProtonMail's OpenPGP implementation
+- **Default Ports**: SMTP (1025), IMAP (1143), CardDAV (8080)
+- **API Endpoint**: https://mail.proton.me/api
+- **Protocol Support**: Allows insecure auth for local connections
+- **IMAP Features**: 
+  - Full nested folder hierarchy support with unlimited depth
+  - ProtonMail Bridge-compatible folder structure (Folders/ and Labels/)
+  - Proper IMAP RFC 3501 compliance for mbsync/isync compatibility
+  - Custom JSON unmarshaling for flexible API response handling
+
+## Dependencies
+
+Main dependencies include:
+- ProtonMail go-crypto for OpenPGP operations
+- emersion's Go email protocol libraries (go-imap, go-smtp, go-webdav)
+- BoltDB (bbolt) for persistent storage
+- Standard Go crypto and networking libraries
+
+## Authentication Flow
+
+1. User authenticates with ProtonMail credentials
+2. 2FA support (TOTP only)
+3. Mailbox password handling (single or two-password mode)
+4. Generate bridge password for email clients
+5. Store encrypted credentials locally
+
+## Security Notes
+
+- Bridge passwords are randomly generated 32-byte keys
+- ProtonMail credentials encrypted with bridge password
+- Supports TLS configuration for production use
+- Client certificate authentication available

--- a/README.md
+++ b/README.md
@@ -91,19 +91,47 @@ Tested on GNOME (Evolution) and Android (DAVDroid).
 
 ### IMAP
 
-IMAP support includes full nested folder hierarchy and is compatible with standard email clients like mbsync/isync.
+IMAP support includes full nested folder hierarchy and comprehensive TLS support, compatible with standard email clients like mbsync/isync.
 
 Features:
 - Full nested folder support with unlimited depth
 - ProtonMail Bridge-compatible folder structure (Folders/ and Labels/)
 - IMAP RFC 3501 compliance for proper email client integration
 - Support for both ProtonMail folders and labels
+- Complete TLS support with automatic certificate generation
 
-For now, it only supports unencrypted local connections.
+Connection options:
 
 ```shell
+# Unencrypted IMAP
 hydroxide imap
+
+# IMAP with STARTTLS using auto-generated certificates (easiest)
+hydroxide -tls-auto-generate imap
+
+# IMAP with STARTTLS using your own certificates
+hydroxide -tls-cert cert.pem -tls-key key.pem imap
+
+# IMAP with implicit TLS (IMAPS)
+hydroxide -tls-cert cert.pem -tls-key key.pem -imap-tls-mode implicit imap
 ```
+
+TLS Options:
+- **Auto-generated certificates**: Use `-tls-auto-generate` for automatic self-signed certificates
+- **Custom certificates**: Provide your own with `-tls-cert` and `-tls-key`
+- **STARTTLS mode** (default): Server starts unencrypted and upgrades to TLS when requested
+- **Implicit TLS mode**: Server requires TLS from connection start (IMAPS)
+- **Client certificate authentication**: Optional CA verification with `-tls-client-ca`
+
+Certificate Storage:
+- Auto-generated certificates are saved to `~/.config/hydroxide/` (Linux/macOS) or `%APPDATA%\hydroxide\` (Windows)
+- Certificates are valid for 1 year and include localhost + 127.0.0.1
+
+Security Notes:
+- Auto-generated certificates are self-signed and suitable for local use
+- For production deployments, use custom certificates from a trusted CA
+- STARTTLS mode is recommended for compatibility with most email clients
+- Implicit TLS mode (IMAPS) provides immediate encryption but may require port 993
 
 Tested with mbsync/isync for Maildir synchronization.
 

--- a/README.md
+++ b/README.md
@@ -91,13 +91,21 @@ Tested on GNOME (Evolution) and Android (DAVDroid).
 
 ### IMAP
 
-⚠️  **Warning**: IMAP support is work-in-progress. Here be dragons.
+IMAP support includes full nested folder hierarchy and is compatible with standard email clients like mbsync/isync.
+
+Features:
+- Full nested folder support with unlimited depth
+- ProtonMail Bridge-compatible folder structure (Folders/ and Labels/)
+- IMAP RFC 3501 compliance for proper email client integration
+- Support for both ProtonMail folders and labels
 
 For now, it only supports unencrypted local connections.
 
 ```shell
 hydroxide imap
 ```
+
+Tested with mbsync/isync for Maildir synchronization.
 
 ## License
 

--- a/config/tls.go
+++ b/config/tls.go
@@ -1,10 +1,19 @@
 package config
 
 import (
+	"crypto/rand"
+	"crypto/rsa"
 	"crypto/tls"
 	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
 	"fmt"
 	"io/ioutil"
+	"math/big"
+	"net"
+	"os"
+	"path/filepath"
+	"time"
 )
 
 func TLS(certPath string, keyPath string, clientCAPath string) (*tls.Config, error) {
@@ -39,4 +48,109 @@ func TLS(certPath string, keyPath string, clientCAPath string) (*tls.Config, err
 	}
 
 	return tlsConfig, nil
+}
+
+// GenerateSelfSignedCert generates a self-signed certificate and key for local use
+func GenerateSelfSignedCert(certPath, keyPath string) error {
+	// Generate private key
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return fmt.Errorf("failed to generate private key: %v", err)
+	}
+
+	// Create certificate template
+	template := x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject: pkix.Name{
+			Organization:  []string{"Hydroxide"},
+			Country:       []string{"US"},
+			Province:      []string{""},
+			Locality:      []string{""},
+			StreetAddress: []string{""},
+			PostalCode:    []string{""},
+		},
+		NotBefore:    time.Now(),
+		NotAfter:     time.Now().Add(365 * 24 * time.Hour), // Valid for 1 year
+		KeyUsage:     x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		IPAddresses:  []net.IP{net.IPv4(127, 0, 0, 1), net.IPv6loopback},
+		DNSNames:     []string{"localhost"},
+	}
+
+	// Create certificate
+	certDER, err := x509.CreateCertificate(rand.Reader, &template, &template, &privateKey.PublicKey, privateKey)
+	if err != nil {
+		return fmt.Errorf("failed to create certificate: %v", err)
+	}
+
+	// Ensure directories exist
+	if err := os.MkdirAll(filepath.Dir(certPath), 0755); err != nil {
+		return fmt.Errorf("failed to create cert directory: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(keyPath), 0755); err != nil {
+		return fmt.Errorf("failed to create key directory: %v", err)
+	}
+
+	// Write certificate file
+	certOut, err := os.Create(certPath)
+	if err != nil {
+		return fmt.Errorf("failed to create cert file: %v", err)
+	}
+	defer certOut.Close()
+
+	if err := pem.Encode(certOut, &pem.Block{Type: "CERTIFICATE", Bytes: certDER}); err != nil {
+		return fmt.Errorf("failed to write certificate: %v", err)
+	}
+
+	// Write private key file
+	keyOut, err := os.Create(keyPath)
+	if err != nil {
+		return fmt.Errorf("failed to create key file: %v", err)
+	}
+	defer keyOut.Close()
+
+	privateKeyPEM := &pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(privateKey)}
+	if err := pem.Encode(keyOut, privateKeyPEM); err != nil {
+		return fmt.Errorf("failed to write private key: %v", err)
+	}
+
+	// Set appropriate permissions on key file
+	if err := os.Chmod(keyPath, 0600); err != nil {
+		return fmt.Errorf("failed to set key file permissions: %v", err)
+	}
+
+	return nil
+}
+
+// TLSWithAutoGenerate handles TLS configuration with optional auto-generation of certificates
+func TLSWithAutoGenerate(certPath string, keyPath string, clientCAPath string, autoGenerate bool) (*tls.Config, error) {
+	if autoGenerate && (certPath == "" || keyPath == "") {
+		// Use default paths in config directory
+		configHome, err := os.UserConfigDir()
+		if err != nil {
+			return nil, fmt.Errorf("failed to get config directory: %v", err)
+		}
+		configDir := filepath.Join(configHome, "hydroxide")
+		
+		if certPath == "" {
+			certPath = filepath.Join(configDir, "hydroxide.crt")
+		}
+		if keyPath == "" {
+			keyPath = filepath.Join(configDir, "hydroxide.key")
+		}
+	}
+
+	// Check if we need to generate certificates
+	if autoGenerate {
+		_, certErr := os.Stat(certPath)
+		_, keyErr := os.Stat(keyPath)
+		
+		if os.IsNotExist(certErr) || os.IsNotExist(keyErr) {
+			if err := GenerateSelfSignedCert(certPath, keyPath); err != nil {
+				return nil, fmt.Errorf("failed to generate self-signed certificate: %v", err)
+			}
+		}
+	}
+
+	return TLS(certPath, keyPath, clientCAPath)
 }


### PR DESCRIPTION
Using Claude Code, full support for nested folders and TLS support has been added. TLS certificate generation can be done automatically with -tls-auto-generate. I have done only minimal testing and can verify that the code compiles and works as expected on FreeBSD 14.3-RELEASE using isync/mbsync and pass.

I was reluctant to submit this pull request because the work was done solely by Claude Code. Go is not a language that know much about. I appreciate the work you've done on this project, so I wanted to offer the solutions I was able to implement, even if it was done with AI. If you choose not to merge these changes with your code base, you should, of course, feel free to use any of the code from this PR.

Thank you for such a cool app.