### PR TITLE
Fix sender not being saved in draft with imap

### DIFF
--- a/imap/message.go
+++ b/imap/message.go
@@ -430,6 +430,10 @@ func createMessage(c *protonmail.Client, u *protonmail.User, privateKeys openpgp
 		Subject:   subject,
 		Header:    formatHeader(mr.Header),
 		AddressID: fromAddr.ID,
+	    Sender: &protonmail.MessageAddress{
+		    Address: fromAddrStr,
+		    Name:    fromList[0].Name,
+	    },
 	}
 
 	// Create an empty draft


### PR DESCRIPTION
Implement the fix proposed by [AlbatorLaho](https://github.com/AlbatorLaho) [here](https://github.com/emersion/hydroxide/issues/174#issuecomment-1558460747).  

This fixes draft not being saved in Thunderbird. 

PR is not complete:
```
AlbatorLaho: it successfully creates a draft of the message you're writing...
except it doesn't seem to update the draft once it's created, rather it creates a new draft every time.
I have no idea how to fix that. (I probably could figure it out if I spend more time on it)
```

I tested and this seems to work as advertised. 
(This test container includes the fix https://hub.docker.com/repository/docker/actuallycoding/hydroxide)
