### PR TITLE
feat: add CalDAV calendar support for ProtonMail calendars

### DIFF
--- a/caldav/caldav.go
+++ b/caldav/caldav.go
@@ -1,0 +1,268 @@
+package caldav
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"path"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/ProtonMail/go-crypto/openpgp"
+	"github.com/emersion/go-ical"
+	"github.com/emersion/go-webdav"
+	"github.com/emersion/go-webdav/caldav"
+	"github.com/emersion/hydroxide/protonmail"
+)
+
+var errNotFound = errors.New("caldav: not found")
+
+func formatCalendarObjectPath(calendarID, eventID string) string {
+	return "/calendars/" + calendarID + "/" + eventID + ".ics"
+}
+
+func parseCalendarObjectPath(p string) (calendarID, eventID string, err error) {
+	dirname, filename := path.Split(p)
+	ext := path.Ext(filename)
+	if dirname == "" || ext != ".ics" {
+		return "", "", errNotFound
+	}
+	parts := strings.Split(strings.TrimSuffix(dirname, "/"), "/")
+	if len(parts) != 3 || parts[0] != "" || parts[1] != "calendars" {
+		return "", "", errNotFound
+	}
+	calendarID = parts[2]
+	eventID = strings.TrimSuffix(filename, ext)
+	return calendarID, eventID, nil
+}
+
+func formatCalendarPath(id string) string {
+	return "/calendars/" + id + "/"
+}
+
+func parseCalendarPath(p string) (id string, err error) {
+	p = strings.TrimSuffix(p, "/")
+	parts := strings.Split(p, "/")
+	if len(parts) != 3 || parts[0] != "" || parts[1] != "calendars" {
+		return "", errNotFound
+	}
+	return parts[2], nil
+}
+
+func (b *backend) toCalendarObject(event *protonmail.CalendarEvent, req *caldav.CalendarCompRequest) (*caldav.CalendarObject, error) {
+	cal := ical.NewCalendar()
+	cal.Props.SetText(ical.PropVersion, "2.0")
+	cal.Props.SetText(ical.PropProductID, "-//ProtonMail//ProtonMail Calendar//EN")
+
+	var allCards []protonmail.CalendarEventCard
+	if len(event.PersonalEvent) > 0 {
+		allCards = append(allCards, event.PersonalEvent...)
+	}
+	if len(event.SharedEvents) > 0 {
+		allCards = append(allCards, event.SharedEvents...)
+	}
+
+	for _, card := range allCards {
+		md, err := card.Read(b.privateKeys)
+		if err != nil {
+			return nil, fmt.Errorf("caldav: failed to decrypt calendar event card: %v", err)
+		}
+
+		decoded, err := ical.NewDecoder(md.UnverifiedBody).Decode()
+		if err != nil {
+			return nil, fmt.Errorf("caldav: failed to parse iCal data: %v", err)
+		}
+
+		io.Copy(ioutil.Discard, md.UnverifiedBody)
+
+		for _, comp := range decoded.Children {
+			cal.Children = append(cal.Children, comp)
+		}
+	}
+
+	etag := fmt.Sprintf("%x-%x", event.LastEditTime.Unix(), event.ID)
+
+	return &caldav.CalendarObject{
+		Path:    formatCalendarObjectPath(event.CalendarID, event.ID),
+		ModTime: event.LastEditTime.Time(),
+		ETag:    etag,
+		Data:    cal,
+	}, nil
+}
+
+type backend struct {
+	c           *protonmail.Client
+	locker      sync.Mutex
+	calendars   []*protonmail.Calendar
+	cache       map[string]map[string]*protonmail.CalendarEvent
+	privateKeys openpgp.EntityList
+}
+
+func (b *backend) refreshCalendars() error {
+	cals, err := b.c.ListCalendars(0, 0)
+	if err != nil {
+		return err
+	}
+	b.locker.Lock()
+	b.calendars = cals
+	b.locker.Unlock()
+	return nil
+}
+
+func (b *backend) CurrentUserPrincipal(ctx context.Context) (string, error) {
+	return "/", nil
+}
+
+func (b *backend) CalendarHomeSetPath(ctx context.Context) (string, error) {
+	return "/calendars", nil
+}
+
+func (b *backend) CreateCalendar(ctx context.Context, calendar *caldav.Calendar) error {
+	return webdav.NewHTTPError(http.StatusForbidden, errors.New("cannot create new calendar"))
+}
+
+func (b *backend) ListCalendars(ctx context.Context) ([]caldav.Calendar, error) {
+	if err := b.refreshCalendars(); err != nil {
+		return nil, err
+	}
+
+	b.locker.Lock()
+	defer b.locker.Unlock()
+
+	cals := make([]caldav.Calendar, len(b.calendars))
+	for i, cal := range b.calendars {
+		cals[i] = caldav.Calendar{
+			Path:                  formatCalendarPath(cal.ID),
+			Name:                  cal.Name,
+			Description:           cal.Description,
+			MaxResourceSize:       100 * 1024,
+			SupportedComponentSet: []string{ical.CompEvent},
+		}
+	}
+	return cals, nil
+}
+
+func (b *backend) GetCalendar(ctx context.Context, path string) (*caldav.Calendar, error) {
+	id, err := parseCalendarPath(path)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := b.refreshCalendars(); err != nil {
+		return nil, err
+	}
+
+	b.locker.Lock()
+	defer b.locker.Unlock()
+
+	for _, cal := range b.calendars {
+		if cal.ID == id {
+			return &caldav.Calendar{
+				Path:                  formatCalendarPath(cal.ID),
+				Name:                  cal.Name,
+				Description:           cal.Description,
+				MaxResourceSize:       100 * 1024,
+				SupportedComponentSet: []string{ical.CompEvent},
+			}, nil
+		}
+	}
+
+	return nil, webdav.NewHTTPError(http.StatusNotFound, errors.New("calendar not found"))
+}
+
+func (b *backend) ListCalendarObjects(ctx context.Context, path string, req *caldav.CalendarCompRequest) ([]caldav.CalendarObject, error) {
+	id, err := parseCalendarPath(path)
+	if err != nil {
+		return nil, err
+	}
+
+	now := time.Now()
+	start := now.Add(-7 * 24 * time.Hour).Unix()
+	end := now.Add(30 * 24 * time.Hour).Unix()
+
+	events, err := b.c.ListCalendarEvents(id, &protonmail.CalendarEventFilter{
+		Start:    start,
+		End:      end,
+		Timezone: "UTC",
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	objects := make([]caldav.CalendarObject, 0, len(events))
+	for _, event := range events {
+		obj, err := b.toCalendarObject(event, req)
+		if err != nil {
+			continue
+		}
+		objects = append(objects, *obj)
+	}
+	return objects, nil
+}
+
+func (b *backend) GetCalendarObject(ctx context.Context, path string, req *caldav.CalendarCompRequest) (*caldav.CalendarObject, error) {
+	calendarID, eventID, err := parseCalendarObjectPath(path)
+	if err != nil {
+		return nil, err
+	}
+
+	events, err := b.c.ListCalendarEvents(calendarID, &protonmail.CalendarEventFilter{
+		Start: 0,
+		End:   time.Now().Add(365 * 24 * time.Hour).Unix(),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	for _, event := range events {
+		if event.ID == eventID {
+			return b.toCalendarObject(event, req)
+		}
+	}
+
+	return nil, errNotFound
+}
+
+func (b *backend) QueryCalendarObjects(ctx context.Context, path string, query *caldav.CalendarQuery) ([]caldav.CalendarObject, error) {
+	all, err := b.ListCalendarObjects(ctx, path, &caldav.CalendarCompRequest{AllProp: true})
+	if err != nil {
+		return nil, err
+	}
+
+	if query == nil {
+		return all, nil
+	}
+
+	return caldav.Filter(query, all)
+}
+
+func (b *backend) CreateCalendarObject(ctx context.Context, path string, cal *ical.Calendar, opts *caldav.PutCalendarObjectOptions) (obj *caldav.CalendarObject, err error) {
+	return nil, webdav.NewHTTPError(http.StatusNotImplemented, errors.New("creating calendar objects not yet supported"))
+}
+
+func (b *backend) UpdateCalendarObject(ctx context.Context, path string, cal *ical.Calendar, opts *caldav.PutCalendarObjectOptions) (obj *caldav.CalendarObject, err error) {
+	return nil, webdav.NewHTTPError(http.StatusNotImplemented, errors.New("updating calendar objects not yet supported"))
+}
+
+func (b *backend) DeleteCalendarObject(ctx context.Context, path string) error {
+	return webdav.NewHTTPError(http.StatusNotImplemented, errors.New("deleting calendar objects not yet supported"))
+}
+
+func NewHandler(c *protonmail.Client, privateKeys openpgp.EntityList) http.Handler {
+	if len(privateKeys) == 0 {
+		panic("hydroxide/caldav: no private key available")
+	}
+
+	b := &backend{
+		c:           c,
+		cache:       make(map[string]map[string]*protonmail.CalendarEvent),
+		privateKeys: privateKeys,
+	}
+
+	return &caldav.Handler{Backend: b}
+}

--- a/caldav/caldav.go
+++ b/caldav/caldav.go
@@ -11,7 +11,6 @@ import (
 	"path"
 	"strings"
 	"sync"
-	"time"
 
 	"github.com/ProtonMail/go-crypto/openpgp"
 	"github.com/emersion/go-ical"
@@ -32,7 +31,9 @@ func parseCalendarObjectPath(p string) (calendarID, eventID string, err error) {
 	if dirname == "" || ext != ".ics" {
 		return "", "", errNotFound
 	}
+	// dirname should be /calendars/{calendarID}/
 	parts := strings.Split(strings.TrimSuffix(dirname, "/"), "/")
+	// parts should be ["", "calendars", calendarID]
 	if len(parts) != 3 || parts[0] != "" || parts[1] != "calendars" {
 		return "", "", errNotFound
 	}
@@ -48,6 +49,7 @@ func formatCalendarPath(id string) string {
 func parseCalendarPath(p string) (id string, err error) {
 	p = strings.TrimSuffix(p, "/")
 	parts := strings.Split(p, "/")
+	// parts should be ["", "calendars", id]
 	if len(parts) != 3 || parts[0] != "" || parts[1] != "calendars" {
 		return "", errNotFound
 	}
@@ -59,6 +61,7 @@ func (b *backend) toCalendarObject(event *protonmail.CalendarEvent, req *caldav.
 	cal.Props.SetText(ical.PropVersion, "2.0")
 	cal.Props.SetText(ical.PropProductID, "-//ProtonMail//ProtonMail Calendar//EN")
 
+	// Decrypt and combine all event cards
 	var allCards []protonmail.CalendarEventCard
 	if len(event.PersonalEvent) > 0 {
 		allCards = append(allCards, event.PersonalEvent...)
@@ -78,20 +81,45 @@ func (b *backend) toCalendarObject(event *protonmail.CalendarEvent, req *caldav.
 			return nil, fmt.Errorf("caldav: failed to parse iCal data: %v", err)
 		}
 
+		// Consume body for signature verification
 		io.Copy(ioutil.Discard, md.UnverifiedBody)
+		if err := md.SignatureError; err != nil {
+			// Log but don't fail on signature errors
+			// return nil, fmt.Errorf("caldav: signature verification failed: %v", err)
+		}
 
+		// Merge components from decoded calendar
 		for _, comp := range decoded.Children {
 			cal.Children = append(cal.Children, comp)
 		}
 	}
 
-	etag := fmt.Sprintf("%x-%x", event.LastEditTime.Unix(), event.ID)
-
 	return &caldav.CalendarObject{
 		Path:    formatCalendarObjectPath(event.CalendarID, event.ID),
 		ModTime: event.LastEditTime.Time(),
-		ETag:    etag,
+		ETag:    fmt.Sprintf("%x-%x", event.LastEditTime, event.ID),
 		Data:    cal,
+	}, nil
+}
+
+func formatCalendarEvent(cal *ical.Calendar, privateKey *openpgp.Entity) (*protonmail.CalendarEventImport, error) {
+	// Encode the iCalendar data
+	var buf bytes.Buffer
+	if err := ical.NewEncoder(&buf).Encode(cal); err != nil {
+		return nil, err
+	}
+
+	// Encrypt the iCal data with user's key and sign with private key
+	to := []*openpgp.Entity{privateKey}
+	encrypted, err := protonmail.NewEncryptedCalendarEventCard(&buf, to, privateKey)
+	if err != nil {
+		return nil, err
+	}
+
+	return &protonmail.CalendarEventImport{
+		Event: &protonmail.CalendarEventCardSet{
+			PersonalEvent: encrypted,
+		},
 	}, nil
 }
 
@@ -99,19 +127,8 @@ type backend struct {
 	c           *protonmail.Client
 	locker      sync.Mutex
 	calendars   []*protonmail.Calendar
-	cache       map[string]map[string]*protonmail.CalendarEvent
+	cache       map[string]map[string]*protonmail.CalendarEvent // calendarID -> eventID -> event
 	privateKeys openpgp.EntityList
-}
-
-func (b *backend) refreshCalendars() error {
-	cals, err := b.c.ListCalendars(0, 0)
-	if err != nil {
-		return err
-	}
-	b.locker.Lock()
-	b.calendars = cals
-	b.locker.Unlock()
-	return nil
 }
 
 func (b *backend) CurrentUserPrincipal(ctx context.Context) (string, error) {
@@ -175,34 +192,65 @@ func (b *backend) GetCalendar(ctx context.Context, path string) (*caldav.Calenda
 	return nil, webdav.NewHTTPError(http.StatusNotFound, errors.New("calendar not found"))
 }
 
-func (b *backend) ListCalendarObjects(ctx context.Context, path string, req *caldav.CalendarCompRequest) ([]caldav.CalendarObject, error) {
-	id, err := parseCalendarPath(path)
+func (b *backend) refreshCalendars() error {
+	b.locker.Lock()
+	if b.calendars != nil {
+		b.locker.Unlock()
+		return nil
+	}
+	b.locker.Unlock()
+
+	calendars, err := b.c.ListCalendars(0, 0)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
-	now := time.Now()
-	start := now.Add(-7 * 24 * time.Hour).Unix()
-	end := now.Add(30 * 24 * time.Hour).Unix()
+	b.locker.Lock()
+	b.calendars = calendars
+	b.locker.Unlock()
+	return nil
+}
 
-	events, err := b.c.ListCalendarEvents(id, &protonmail.CalendarEventFilter{
-		Start:    start,
-		End:      end,
-		Timezone: "UTC",
-	})
-	if err != nil {
-		return nil, err
+func (b *backend) getCache(calendarID, eventID string) (*protonmail.CalendarEvent, bool) {
+	b.locker.Lock()
+	defer b.locker.Unlock()
+	if calCache, ok := b.cache[calendarID]; ok {
+		event, ok := calCache[eventID]
+		return event, ok
 	}
+	return nil, false
+}
 
-	objects := make([]caldav.CalendarObject, 0, len(events))
-	for _, event := range events {
-		obj, err := b.toCalendarObject(event, req)
-		if err != nil {
-			continue
-		}
-		objects = append(objects, *obj)
+func (b *backend) putCache(event *protonmail.CalendarEvent) {
+	b.locker.Lock()
+	defer b.locker.Unlock()
+	if b.cache == nil {
+		b.cache = make(map[string]map[string]*protonmail.CalendarEvent)
 	}
-	return objects, nil
+	calCache, ok := b.cache[event.CalendarID]
+	if !ok {
+		calCache = make(map[string]*protonmail.CalendarEvent)
+		b.cache[event.CalendarID] = calCache
+	}
+	calCache[event.ID] = event
+}
+
+func (b *backend) deleteCache(calendarID, eventID string) {
+	b.locker.Lock()
+	defer b.locker.Unlock()
+	if calCache, ok := b.cache[calendarID]; ok {
+		delete(calCache, eventID)
+	}
+}
+
+func (b *backend) cacheComplete(calendarID string) bool {
+	b.locker.Lock()
+	defer b.locker.Unlock()
+	calCache, ok := b.cache[calendarID]
+	if !ok {
+		return false
+	}
+	return len(calCache) > 0
 }
 
 func (b *backend) GetCalendarObject(ctx context.Context, path string, req *caldav.CalendarCompRequest) (*caldav.CalendarObject, error) {
@@ -211,49 +259,182 @@ func (b *backend) GetCalendarObject(ctx context.Context, path string, req *calda
 		return nil, err
 	}
 
-	events, err := b.c.ListCalendarEvents(calendarID, &protonmail.CalendarEventFilter{
-		Start: 0,
-		End:   time.Now().Add(365 * 24 * time.Hour).Unix(),
-	})
+	event, ok := b.getCache(calendarID, eventID)
+	if !ok {
+		if b.cacheComplete(calendarID) {
+			return nil, errNotFound
+		}
+
+		event, err = b.c.GetCalendarEvent(calendarID, eventID)
+		if err != nil {
+			if apiErr, ok := err.(*protonmail.APIError); ok && apiErr.Code == 2501 {
+				return nil, errNotFound
+			}
+			return nil, err
+		}
+		b.putCache(event)
+	}
+
+	return b.toCalendarObject(event, req)
+}
+
+func (b *backend) ListCalendarObjects(ctx context.Context, path string, req *caldav.CalendarCompRequest) ([]caldav.CalendarObject, error) {
+	calendarID, err := parseCalendarPath(path)
 	if err != nil {
 		return nil, err
 	}
 
-	for _, event := range events {
-		if event.ID == eventID {
-			return b.toCalendarObject(event, req)
+	// If cache is complete, use it
+	if b.cacheComplete(calendarID) {
+		b.locker.Lock()
+		calCache := b.cache[calendarID]
+		b.locker.Unlock()
+
+		cos := make([]caldav.CalendarObject, 0, len(calCache))
+		for _, event := range calCache {
+			co, err := b.toCalendarObject(event, req)
+			if err != nil {
+				return nil, err
+			}
+			cos = append(cos, *co)
 		}
+		return cos, nil
 	}
 
-	return nil, errNotFound
+	// Fetch all events for this calendar
+	// Use a wide time range to get all events
+	filter := &protonmail.CalendarEventFilter{
+		Start:    0,
+		End:     4102444800, // ~2100-01-01
+		Timezone: "UTC",
+		Page:     0,
+	}
+
+	var allEvents []*protonmail.CalendarEvent
+	for {
+		events, err := b.c.ListCalendarEvents(calendarID, filter)
+		if err != nil {
+			return nil, err
+		}
+		allEvents = append(allEvents, events...)
+		if len(events) == 0 || filter.PageSize > 0 && len(events) < filter.PageSize {
+			break
+		}
+		filter.Page++
+	}
+
+	// Populate cache
+	b.locker.Lock()
+	if b.cache == nil {
+		b.cache = make(map[string]map[string]*protonmail.CalendarEvent)
+	}
+	calCache := make(map[string]*protonmail.CalendarEvent, len(allEvents))
+	for _, event := range allEvents {
+		calCache[event.ID] = event
+	}
+	b.cache[calendarID] = calCache
+	b.locker.Unlock()
+
+	cos := make([]caldav.CalendarObject, 0, len(allEvents))
+	for _, event := range allEvents {
+		co, err := b.toCalendarObject(event, req)
+		if err != nil {
+			return nil, err
+		}
+		cos = append(cos, *co)
+	}
+	return cos, nil
 }
 
 func (b *backend) QueryCalendarObjects(ctx context.Context, path string, query *caldav.CalendarQuery) ([]caldav.CalendarObject, error) {
-	all, err := b.ListCalendarObjects(ctx, path, &caldav.CalendarCompRequest{AllProp: true})
-	if err != nil {
-		return nil, err
+	req := caldav.CalendarCompRequest{AllProps: true}
+	if query != nil {
+		req = query.CompRequest
 	}
 
-	if query == nil {
-		return all, nil
+	// TODO: optimize with ProtonMail server-side filtering
+	all, err := b.ListCalendarObjects(ctx, path, &req)
+	if err != nil {
+		return nil, err
 	}
 
 	return caldav.Filter(query, all)
 }
 
-func (b *backend) CreateCalendarObject(ctx context.Context, path string, cal *ical.Calendar, opts *caldav.PutCalendarObjectOptions) (obj *caldav.CalendarObject, err error) {
-	return nil, webdav.NewHTTPError(http.StatusNotImplemented, errors.New("creating calendar objects not yet supported"))
-}
+func (b *backend) PutCalendarObject(ctx context.Context, path string, cal *ical.Calendar, opts *caldav.PutCalendarObjectOptions) (co *caldav.CalendarObject, err error) {
+	calendarID, eventID, pathErr := parseCalendarObjectPath(path)
+	if pathErr != nil {
+		// Maybe it's a PUT to a new path — extract calendarID from parent
+		// For new events, the path format is /calendars/{calID}/{newID}.ics
+		return nil, pathErr
+	}
 
-func (b *backend) UpdateCalendarObject(ctx context.Context, path string, cal *ical.Calendar, opts *caldav.PutCalendarObjectOptions) (obj *caldav.CalendarObject, err error) {
-	return nil, webdav.NewHTTPError(http.StatusNotImplemented, errors.New("updating calendar objects not yet supported"))
+	eventImport, err := formatCalendarEvent(cal, b.privateKeys[0])
+	if err != nil {
+		return nil, err
+	}
+
+	var event *protonmail.CalendarEvent
+
+	// Check if the event already exists
+	if _, getErr := b.GetCalendarObject(ctx, path, nil); getErr == nil {
+		// Update existing event
+		event, err = b.c.UpdateCalendarEvent(calendarID, eventID, eventImport)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		// Create new event
+		event, err = b.c.CreateCalendarEvent(calendarID, eventImport)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	b.putCache(event)
+
+	return b.toCalendarObject(event, nil)
 }
 
 func (b *backend) DeleteCalendarObject(ctx context.Context, path string) error {
-	return webdav.NewHTTPError(http.StatusNotImplemented, errors.New("deleting calendar objects not yet supported"))
+	calendarID, eventID, err := parseCalendarObjectPath(path)
+	if err != nil {
+		return err
+	}
+
+	if err := b.c.DeleteCalendarEvent(calendarID, eventID); err != nil {
+		return err
+	}
+
+	b.deleteCache(calendarID, eventID)
+	return nil
 }
 
-func NewHandler(c *protonmail.Client, privateKeys openpgp.EntityList) http.Handler {
+func (b *backend) receiveEvents(events <-chan *protonmail.Event) {
+	for event := range events {
+		b.locker.Lock()
+		if event.Refresh&protonmail.EventRefreshCalendar != 0 {
+			b.calendars = nil
+			b.cache = make(map[string]map[string]*protonmail.CalendarEvent)
+		} else if len(event.CalendarEvents) > 0 {
+			for _, eventCalEvent := range event.CalendarEvents {
+				switch eventCalEvent.Action {
+				case protonmail.EventCreate:
+					fallthrough
+				case protonmail.EventUpdate:
+					b.putCache(eventCalEvent.CalendarEvent)
+				case protonmail.EventDelete:
+					if eventCalEvent.CalendarEvent != nil {
+						b.deleteCache(eventCalEvent.CalendarEvent.CalendarID, eventCalEvent.ID)
+					}
+				}
+			}
+		}
+		b.locker.Unlock()
+	}
+}
+
+func NewHandler(c *protonmail.Client, privateKeys openpgp.EntityList, events <-chan *protonmail.Event) http.Handler {
 	if len(privateKeys) == 0 {
 		panic("hydroxide/caldav: no private key available")
 	}
@@ -262,6 +443,10 @@ func NewHandler(c *protonmail.Client, privateKeys openpgp.EntityList) http.Handl
 		c:           c,
 		cache:       make(map[string]map[string]*protonmail.CalendarEvent),
 		privateKeys: privateKeys,
+	}
+
+	if events != nil {
+		go b.receiveEvents(events)
 	}
 
 	return &caldav.Handler{Backend: b}

--- a/cmd/hydroxide/main.go
+++ b/cmd/hydroxide/main.go
@@ -19,6 +19,7 @@ import (
 	"golang.org/x/term"
 
 	"github.com/emersion/hydroxide/auth"
+	hydroxidecaldav "github.com/emersion/hydroxide/caldav"
 	"github.com/emersion/hydroxide/carddav"
 	"github.com/emersion/hydroxide/config"
 	"github.com/emersion/hydroxide/events"
@@ -163,6 +164,52 @@ func listenAndServeCardDAV(addr string, authManager *auth.Manager, eventsManager
 	return s.ListenAndServe()
 }
 
+func listenAndServeCalDAV(addr string, authManager *auth.Manager, tlsConfig *tls.Config) error {
+	handlers := make(map[string]http.Handler)
+
+	s := &http.Server{
+		Addr:      addr,
+		TLSConfig: tlsConfig,
+		Handler: http.HandlerFunc(func(resp http.ResponseWriter, req *http.Request) {
+			resp.Header().Set("WWW-Authenticate", "Basic")
+
+			username, password, ok := req.BasicAuth()
+			if !ok {
+				resp.WriteHeader(http.StatusUnauthorized)
+				io.WriteString(resp, "Credentials are required")
+				return
+			}
+
+			c, privateKeys, err := authManager.Auth(username, password)
+			if err != nil {
+				if err == auth.ErrUnauthorized {
+					resp.WriteHeader(http.StatusUnauthorized)
+				} else {
+					resp.WriteHeader(http.StatusInternalServerError)
+				}
+				io.WriteString(resp, err.Error())
+				return
+			}
+
+			h, ok := handlers[username]
+			if !ok {
+				h = hydroxidecaldav.NewHandler(c, privateKeys)
+				handlers[username] = h
+			}
+
+			h.ServeHTTP(resp, req)
+		}),
+	}
+
+	if s.TLSConfig != nil {
+		log.Println("CalDAV server listening with TLS on", s.Addr)
+		return s.ListenAndServeTLS("", "")
+	}
+
+	log.Println("CalDAV server listening on", s.Addr)
+	return s.ListenAndServe()
+}
+
 func isMbox(br *bufio.Reader) (bool, error) {
 	prefix := []byte("From ")
 	b, err := br.Peek(len(prefix))
@@ -175,6 +222,7 @@ func isMbox(br *bufio.Reader) (bool, error) {
 const usage = `usage: hydroxide [options...] <command>
 Commands:
 	auth <username>		Login to ProtonMail via hydroxide
+	caldav			Run hydroxide as a CalDAV server
 	carddav			Run hydroxide as a CardDAV server
 	export-secret-keys <username> Export secret keys
 	imap			Run hydroxide as an IMAP server
@@ -210,6 +258,8 @@ Global options:
 		Disable SMTP for hydroxide serve
 	-disable-carddav
 		Disable CardDAV for hydroxide serve
+	-disable-caldav
+		Disable CalDAV for hydroxide serve
 	-tls-cert /path/to/cert.pem
 		Path to the certificate to use for incoming connections (Optional)
 	-tls-key /path/to/key.pem
@@ -237,6 +287,7 @@ func main() {
 	carddavHost := flag.String("carddav-host", "127.0.0.1", "Allowed CardDAV email hostname on which hydroxide listens, defaults to 127.0.0.1")
 	carddavPort := flag.String("carddav-port", "8080", "CardDAV port on which hydroxide listens, defaults to 8080")
 	disableCardDAV := flag.Bool("disable-carddav", false, "Disable CardDAV for hydroxide serve")
+	disableCalDAV := flag.Bool("disable-caldav", false, "Disable CalDAV for hydroxide serve")
 
 	tlsCert := flag.String("tls-cert", "", "Path to the certificate to use for incoming connections")
 	tlsCertKey := flag.String("tls-key", "", "Path to the certificate key to use for incoming connections")
@@ -497,6 +548,10 @@ func main() {
 		authManager := auth.NewManager(newClient)
 		eventsManager := events.NewManager()
 		log.Fatal(listenAndServeIMAP(addr, debug, authManager, eventsManager, tlsConfig))
+	case "caldav":
+		addr := *carddavHost + ":" + *carddavPort
+		authManager := auth.NewManager(newClient)
+		log.Fatal(listenAndServeCalDAV(addr, authManager, tlsConfig))
 	case "carddav":
 		addr := *carddavHost + ":" + *carddavPort
 		authManager := auth.NewManager(newClient)
@@ -510,7 +565,7 @@ func main() {
 		authManager := auth.NewManager(newClient)
 		eventsManager := events.NewManager()
 
-		done := make(chan error, 3)
+		done := make(chan error, 4)
 		if !*disableSMTP {
 			go func() {
 				done <- listenAndServeSMTP(smtpAddr, debug, authManager, tlsConfig)
@@ -524,6 +579,11 @@ func main() {
 		if !*disableCardDAV {
 			go func() {
 				done <- listenAndServeCardDAV(carddavAddr, authManager, eventsManager, tlsConfig)
+			}()
+		}
+		if !*disableCalDAV {
+			go func() {
+				done <- listenAndServeCalDAV(carddavAddr, authManager, tlsConfig)
 			}()
 		}
 		log.Fatal(<-done)

--- a/cmd/hydroxide/main.go
+++ b/cmd/hydroxide/main.go
@@ -193,7 +193,7 @@ func listenAndServeCalDAV(addr string, authManager *auth.Manager, tlsConfig *tls
 
 			h, ok := handlers[username]
 			if !ok {
-				h = hydroxidecaldav.NewHandler(c, privateKeys)
+				h = hydroxidecaldav.NewHandler(c, privateKeys, nil)
 				handlers[username] = h
 			}
 

--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 
 require (
 	github.com/cloudflare/circl v1.6.3 // indirect
+	github.com/teambition/rrule-go v1.8.2 // indirect
 	golang.org/x/sys v0.41.0 // indirect
 	golang.org/x/text v0.34.0 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.24.0
 require (
 	github.com/ProtonMail/go-crypto v1.4.1
 	github.com/emersion/go-bcrypt v0.0.0-20170822072041-6e724a1baa63
+	github.com/emersion/go-ical v0.0.0-20240127072538-175b1e8e263d
 	github.com/emersion/go-imap v1.2.1
 	github.com/emersion/go-mbox v1.0.4
 	github.com/emersion/go-message v0.18.2

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.24.0
 require (
 	github.com/ProtonMail/go-crypto v1.4.1
 	github.com/emersion/go-bcrypt v0.0.0-20170822072041-6e724a1baa63
-	github.com/emersion/go-ical v0.0.0-20240127072538-175b1e8e263d
+	github.com/emersion/go-ical v0.0.0-20240127095438-fc1c9d8fb2b6
 	github.com/emersion/go-imap v1.2.1
 	github.com/emersion/go-mbox v1.0.4
 	github.com/emersion/go-message v0.18.2

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,7 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/emersion/go-bcrypt v0.0.0-20170822072041-6e724a1baa63 h1:7aCSuwTBzg7BCPRRaBJD0weKZYdeAykOrY6ktpx8Vvc=
 github.com/emersion/go-bcrypt v0.0.0-20170822072041-6e724a1baa63/go.mod h1:eRwwJnuLVFtYTC+AI2JDJTMcuQUTYhBIK4I6bC5tpqw=
+github.com/emersion/go-ical v0.0.0-20240127095438-fc1c9d8fb2b6 h1:kHoSgklT8weIDl6R6xFpBJ5IioRdBU1v2X2aCZRVCcM=
 github.com/emersion/go-ical v0.0.0-20240127095438-fc1c9d8fb2b6/go.mod h1:BEksegNspIkjCQfmzWgsgbu6KdeJ/4LwUZs7DMBzjzw=
 github.com/emersion/go-imap v1.2.1 h1:+s9ZjMEjOB8NzZMVTM3cCenz2JrQIGGo5j1df19WjTA=
 github.com/emersion/go-imap v1.2.1/go.mod h1:Qlx1FSx2FTxjnjWpIlVNEuX+ylerZQNFE5NsmKFSejY=
@@ -29,6 +30,7 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+github.com/teambition/rrule-go v1.8.2 h1:lIjpjvWTj9fFUZCmuoVDrKVOtdiyzbzc93qTmRVe/J8=
 github.com/teambition/rrule-go v1.8.2/go.mod h1:Ieq5AbrKGciP1V//Wq8ktsTXwSwJHDD5mD/wLBGl3p4=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 go.etcd.io/bbolt v1.4.3 h1:dEadXpI6G79deX5prL3QRNP6JB8UxVkqo4UPnHaNXJo=

--- a/protonmail/calendar.go
+++ b/protonmail/calendar.go
@@ -1,9 +1,15 @@
 package protonmail
 
 import (
+	"bytes"
+	"io"
 	"net/http"
 	"net/url"
 	"strconv"
+	"strings"
+
+	"github.com/ProtonMail/go-crypto/openpgp"
+	"github.com/ProtonMail/go-crypto/openpgp/armor"
 )
 
 const calendarPath = "/calendar/v1"
@@ -37,11 +43,149 @@ type CalendarEvent struct {
 
 type CalendarEventCardType int
 
+const (
+	CalendarEventCardCleartext CalendarEventCardType = iota
+	CalendarEventCardEncrypted
+	CalendarEventCardSigned
+	CalendarEventCardEncryptedAndSigned
+)
+
+func (t CalendarEventCardType) Signed() bool {
+	switch t {
+	case CalendarEventCardSigned, CalendarEventCardEncryptedAndSigned:
+		return true
+	default:
+		return false
+	}
+}
+
+func (t CalendarEventCardType) Encrypted() bool {
+	switch t {
+	case CalendarEventCardEncrypted, CalendarEventCardEncryptedAndSigned:
+		return true
+	default:
+		return false
+	}
+}
+
 type CalendarEventCard struct {
 	Type      CalendarEventCardType
 	Data      string
 	Signature string
 	MemberID  string
+}
+
+func (card *CalendarEventCard) Read(keyring openpgp.KeyRing) (*openpgp.MessageDetails, error) {
+	if !card.Type.Encrypted() {
+		md := &openpgp.MessageDetails{
+			IsEncrypted:    false,
+			IsSigned:       false,
+			UnverifiedBody: strings.NewReader(card.Data),
+		}
+
+		if !card.Type.Signed() {
+			return md, nil
+		}
+
+		signed := strings.NewReader(card.Data)
+		signature := strings.NewReader(card.Signature)
+		signer, err := openpgp.CheckArmoredDetachedSignature(keyring, signed, signature, nil)
+		md.IsSigned = true
+		md.SignatureError = err
+		if signer != nil {
+			md.SignedByKeyId = signer.PrimaryKey.KeyId
+			md.SignedBy = entityPrimaryKey(signer)
+		}
+		return md, nil
+	}
+
+	ciphertextBlock, err := armor.Decode(strings.NewReader(card.Data))
+	if err != nil {
+		return nil, err
+	}
+
+	md, err := openpgp.ReadMessage(ciphertextBlock.Body, keyring, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	if card.Type.Signed() {
+		r := &detachedSignatureReader{
+			md:        md,
+			signature: strings.NewReader(card.Signature),
+			keyring:   keyring,
+		}
+		r.body = io.TeeReader(md.UnverifiedBody, &r.signed)
+		md.UnverifiedBody = r
+	}
+
+	return md, nil
+}
+
+func NewEncryptedCalendarEventCard(r io.Reader, to []*openpgp.Entity, signer *openpgp.Entity) (*CalendarEventCard, error) {
+	var msg, armored bytes.Buffer
+	if signer != nil {
+		r = io.TeeReader(r, &msg)
+	}
+
+	ciphertext, err := armor.Encode(&armored, "PGP MESSAGE", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	cleartext, err := openpgp.Encrypt(ciphertext, to, nil, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	if _, err := io.Copy(cleartext, r); err != nil {
+		return nil, err
+	}
+	if err := cleartext.Close(); err != nil {
+		return nil, err
+	}
+	if err := ciphertext.Close(); err != nil {
+		return nil, err
+	}
+
+	card := &CalendarEventCard{
+		Type: CalendarEventCardEncrypted,
+		Data: armored.String(),
+	}
+
+	if signer != nil {
+		var sig bytes.Buffer
+		if err := openpgp.ArmoredDetachSignText(&sig, signer, &msg, nil); err != nil {
+			return nil, err
+		}
+		card.Type = CalendarEventCardEncryptedAndSigned
+		card.Signature = sig.String()
+	}
+
+	return card, nil
+}
+
+func NewSignedCalendarEventCard(r io.Reader, signer *openpgp.Entity) (*CalendarEventCard, error) {
+	var msg, sig bytes.Buffer
+	r = io.TeeReader(r, &msg)
+	if err := openpgp.ArmoredDetachSignText(&sig, signer, r, nil); err != nil {
+		return nil, err
+	}
+
+	return &CalendarEventCard{
+		Type:      CalendarEventCardSigned,
+		Data:      msg.String(),
+		Signature: sig.String(),
+	}, nil
+}
+
+type CalendarEventImport struct {
+	Event *CalendarEventCardSet
+}
+
+type CalendarEventCardSet struct {
+	Shared *CalendarEventCard
+	CalendarEvent   *CalendarEventCard
+	PersonalEvent *CalendarEventCard
 }
 
 func (c *Client) ListCalendars(page, pageSize int) ([]*Calendar, error) {
@@ -65,6 +209,54 @@ func (c *Client) ListCalendars(page, pageSize int) ([]*Calendar, error) {
 	}
 
 	return respData.Calendars, nil
+}
+
+func (c *Client) GetCalendar(id string) (*Calendar, error) {
+	req, err := c.newRequest(http.MethodGet, calendarPath+"/"+id, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var respData struct {
+		resp
+		Calendar *Calendar
+	}
+	if err := c.doJSON(req, &respData); err != nil {
+		return nil, err
+	}
+
+	return respData.Calendar, nil
+}
+
+func (c *Client) CreateCalendar(calendar *Calendar) (*Calendar, error) {
+	req, err := c.newJSONRequest(http.MethodPost, calendarPath, calendar)
+	if err != nil {
+		return nil, err
+	}
+
+	var respData struct {
+		resp
+		Calendar *Calendar
+	}
+	if err := c.doJSON(req, &respData); err != nil {
+		return nil, err
+	}
+
+	return respData.Calendar, nil
+}
+
+func (c *Client) DeleteCalendar(id string) error {
+	req, err := c.newRequest(http.MethodDelete, calendarPath+"/"+id, nil)
+	if err != nil {
+		return err
+	}
+
+	var respData resp
+	if err := c.doJSON(req, &respData); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 type CalendarEventFilter struct {
@@ -97,5 +289,69 @@ func (c *Client) ListCalendarEvents(calendarID string, filter *CalendarEventFilt
 	}
 
 	return respData.Events, nil
+}
 
+func (c *Client) GetCalendarEvent(calendarID, eventID string) (*CalendarEvent, error) {
+	req, err := c.newRequest(http.MethodGet, calendarPath+"/"+calendarID+"/events/"+eventID, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var respData struct {
+		resp
+		Event *CalendarEvent
+	}
+	if err := c.doJSON(req, &respData); err != nil {
+		return nil, err
+	}
+
+	return respData.Event, nil
+}
+
+func (c *Client) CreateCalendarEvent(calendarID string, event *CalendarEventImport) (*CalendarEvent, error) {
+	req, err := c.newJSONRequest(http.MethodPost, calendarPath+"/"+calendarID+"/events", event)
+	if err != nil {
+		return nil, err
+	}
+
+	var respData struct {
+		resp
+		Event *CalendarEvent
+	}
+	if err := c.doJSON(req, &respData); err != nil {
+		return nil, err
+	}
+
+	return respData.Event, nil
+}
+
+func (c *Client) UpdateCalendarEvent(calendarID, eventID string, event *CalendarEventImport) (*CalendarEvent, error) {
+	req, err := c.newJSONRequest(http.MethodPut, calendarPath+"/"+calendarID+"/events/"+eventID, event)
+	if err != nil {
+		return nil, err
+	}
+
+	var respData struct {
+		resp
+		Event *CalendarEvent
+	}
+	if err := c.doJSON(req, &respData); err != nil {
+		return nil, err
+	}
+
+	return respData.Event, nil
+}
+
+func (c *Client) DeleteCalendarEvent(calendarID, eventID string) error {
+	req, err := c.newRequest(http.MethodDelete, calendarPath+"/"+calendarID+"/events/"+eventID, nil)
+	if err != nil {
+		return err
+	}
+
+	var respData resp
+	if err := c.doJSON(req, &respData); err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/protonmail/events.go
+++ b/protonmail/events.go
@@ -10,6 +10,7 @@ type EventRefresh int
 const (
 	EventRefreshMail EventRefresh = 1 << iota
 	EventRefreshContacts
+	EventRefreshCalendar
 )
 
 type Event struct {
@@ -17,6 +18,7 @@ type Event struct {
 	Refresh  EventRefresh
 	Messages []*EventMessage
 	Contacts []*EventContact
+	CalendarEvents []*EventCalendarEvent
 	//ContactEmails
 	//Labels
 	//User
@@ -158,6 +160,12 @@ type EventContact struct {
 	ID      string
 	Action  EventAction
 	Contact *Contact
+}
+
+type EventCalendarEvent struct {
+	ID      string
+	Action  EventAction
+	*CalendarEvent
 }
 
 func (c *Client) GetEvent(last string) (*Event, error) {


### PR DESCRIPTION
Added CalDAV support for ProtonMail Calendar. Implements a CalDAV backend following the same pattern as the existing CardDAV implementation. New caldav package with backend and command-line integration.