### PR TITLE
feat: add CalDAV server support

### DIFF
--- a/caldav/caldav.go
+++ b/caldav/caldav.go
@@ -1,0 +1,211 @@
+package caldav
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"path"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/emersion/go-ical"
+	"github.com/emersion/go-webdav"
+	"github.com/emersion/go-webdav/caldav"
+	"github.com/emersion/hydroxide/protonmail"
+)
+
+var errNotFound = errors.New("caldav: not found")
+
+var defaultCalendar = &caldav.Calendar{
+	Path:        "/calendars/default",
+	Name:        "ProtonMail",
+	Description: "ProtonMail calendar",
+}
+
+func parseCalendarObjectPath(p string) (string, error) {
+	dirname, filename := path.Split(p)
+	ext := path.Ext(filename)
+	if dirname != "/calendars/default/" || ext != ".ics" {
+		return "", errNotFound
+	}
+	return strings.TrimSuffix(filename, ext), nil
+}
+
+func formatCalendarObjectPath(id string) string {
+	return "/calendars/default/" + id + ".ics"
+}
+
+func timestampToTime(ts protonmail.Timestamp) time.Time {
+	return ts.Time()
+}
+
+func calendarEventToIcal(event *protonmail.CalendarEvent) (*ical.Calendar, error) {
+	cal := ical.NewCalendar()
+	cal.Props.SetText(ical.PropVersion, "2.0")
+	cal.Props.SetText(ical.ProdID, "-//hydroxide//EN")
+
+	// Decode shared events
+	for _, sharedEvent := range event.SharedEvents {
+		comp := ical.NewComponent(ical.CompEvent)
+		comp.Props.SetText(ical.PropUID, event.ID)
+
+		// Parse the event data (iCal format stored by ProtonMail)
+		if sharedEvent.Data != "" {
+			// ProtonMail stores event data as iCal, parse and copy properties
+			parser := ical.NewDecoder(strings.NewReader(sharedEvent.Data))
+			parsed, err := parser.Decode()
+			if err == nil {
+				for _, child := range parsed.Children {
+					for propName, props := range child.Props {
+						for _, prop := range props {
+							comp.Props.Add(propName, prop)
+						}
+					}
+				}
+			}
+		}
+
+		// Set timestamps
+		if !event.CreateTime.Time().IsZero() {
+			comp.Props.SetDateTime(ical.PropCreated, event.CreateTime.Time())
+		}
+		if !event.LastEditTime.Time().IsZero() {
+			comp.Props.SetDateTime(ical.PropLastModified, event.LastEditTime.Time())
+		}
+
+		cal.Children = append(cal.Children, comp)
+	}
+
+	return cal, nil
+}
+
+type backend struct {
+	c      *protonmail.Client
+	cache  map[string]*protonmail.CalendarEvent
+	locker sync.Mutex
+}
+
+func (b *backend) CurrentUserPrincipal(ctx context.Context) (string, error) {
+	return "/", nil
+}
+
+func (b *backend) CalendarHomeSetPath(ctx context.Context) (string, error) {
+	return "/calendars", nil
+}
+
+func (b *backend) CreateCalendar(ctx context.Context, calendar *caldav.Calendar) error {
+	return webdav.NewHTTPError(http.StatusForbidden, errors.New("cannot create new calendar"))
+}
+
+func (b *backend) ListCalendars(ctx context.Context) ([]caldav.Calendar, error) {
+	return []caldav.Calendar{*defaultCalendar}, nil
+}
+
+func (b *backend) GetCalendar(ctx context.Context, calendarPath string) (*caldav.Calendar, error) {
+	if calendarPath != defaultCalendar.Path {
+		return nil, webdav.NewHTTPError(http.StatusNotFound, errors.New("calendar not found"))
+	}
+	return defaultCalendar, nil
+}
+
+func (b *backend) GetCalendarObject(ctx context.Context, path string, req *caldav.CalendarCompRequest) (*caldav.CalendarObject, error) {
+	id, err := parseCalendarObjectPath(path)
+	if err != nil {
+		return nil, err
+	}
+
+	b.locker.Lock()
+	event, ok := b.cache[id]
+	b.locker.Unlock()
+
+	if !ok {
+		return nil, errNotFound
+	}
+
+	cal, err := calendarEventToIcal(event)
+	if err != nil {
+		return nil, err
+	}
+
+	return &caldav.CalendarObject{
+		Path:    formatCalendarObjectPath(event.ID),
+		ModTime: timestampToTime(event.LastEditTime),
+		ETag:    fmt.Sprintf("%x", event.LastEditTime),
+		Data:    cal,
+	}, nil
+}
+
+func (b *backend) ListCalendarObjects(ctx context.Context, path string, req *caldav.CalendarCompRequest) ([]caldav.CalendarObject, error) {
+	if path != defaultCalendar.Path {
+		return nil, errNotFound
+	}
+
+	// Get calendars from ProtonMail
+	calendars, err := b.c.ListCalendars(0, 0)
+	if err != nil {
+		return nil, err
+	}
+
+	var objs []caldav.CalendarObject
+	for _, cal := range calendars {
+		// Get events for each calendar
+		filter := &protonmail.CalendarEventFilter{
+			Start:    time.Now().AddDate(-1, 0, 0).Unix(),
+			End:      time.Now().AddDate(1, 0, 0).Unix(),
+			Timezone: "UTC",
+			Page:     0,
+			PageSize: 100,
+		}
+
+		events, err := b.c.ListCalendarEvents(cal.ID, filter)
+		if err != nil {
+			continue
+		}
+
+		for _, event := range events {
+			b.locker.Lock()
+			b.cache[event.ID] = event
+			b.locker.Unlock()
+
+			ical, err := calendarEventToIcal(event)
+			if err != nil {
+				continue
+			}
+
+			objs = append(objs, caldav.CalendarObject{
+				Path:    formatCalendarObjectPath(event.ID),
+				ModTime: timestampToTime(event.LastEditTime),
+				ETag:    fmt.Sprintf("%x", event.LastEditTime),
+				Data:    ical,
+			})
+		}
+	}
+
+	return objs, nil
+}
+
+func (b *backend) QueryCalendarObjects(ctx context.Context, path string, query *caldav.CalendarQuery) ([]caldav.CalendarObject, error) {
+	req := caldav.CalendarCompRequest{AllProp: true}
+	if query != nil {
+		req = query.CompRequest
+	}
+	return b.ListCalendarObjects(ctx, path, &req)
+}
+
+func (b *backend) PutCalendarObject(ctx context.Context, path string, calendar *ical.Calendar, opts *caldav.PutCalendarObjectOptions) (*caldav.CalendarObject, error) {
+	return nil, webdav.NewHTTPError(http.StatusNotImplemented, errors.New("put calendar object not implemented"))
+}
+
+func (b *backend) DeleteCalendarObject(ctx context.Context, path string) error {
+	return webdav.NewHTTPError(http.StatusNotImplemented, errors.New("delete calendar object not implemented"))
+}
+
+func NewHandler(c *protonmail.Client) http.Handler {
+	b := &backend{
+		c:     c,
+		cache: make(map[string]*protonmail.CalendarEvent),
+	}
+	return &caldav.Handler{Backend: b}
+}

--- a/cmd/hydroxide/main.go
+++ b/cmd/hydroxide/main.go
@@ -19,6 +19,7 @@ import (
 	"golang.org/x/term"
 
 	"github.com/emersion/hydroxide/auth"
+	"github.com/emersion/hydroxide/caldav"
 	"github.com/emersion/hydroxide/carddav"
 	"github.com/emersion/hydroxide/config"
 	"github.com/emersion/hydroxide/events"
@@ -163,6 +164,52 @@ func listenAndServeCardDAV(addr string, authManager *auth.Manager, eventsManager
 	return s.ListenAndServe()
 }
 
+func listenAndServeCalDAV(addr string, authManager *auth.Manager, tlsConfig *tls.Config) error {
+	handlers := make(map[string]http.Handler)
+
+	s := &http.Server{
+		Addr:      addr,
+		TLSConfig: tlsConfig,
+		Handler: http.HandlerFunc(func(resp http.ResponseWriter, req *http.Request) {
+			resp.Header().Set("WWW-Authenticate", "Basic")
+
+			username, password, ok := req.BasicAuth()
+			if !ok {
+				resp.WriteHeader(http.StatusUnauthorized)
+				io.WriteString(resp, "Credentials are required")
+				return
+			}
+
+			c, _, err := authManager.Auth(username, password)
+			if err != nil {
+				if err == auth.ErrUnauthorized {
+					resp.WriteHeader(http.StatusUnauthorized)
+				} else {
+					resp.WriteHeader(http.StatusInternalServerError)
+				}
+				io.WriteString(resp, err.Error())
+				return
+			}
+
+			h, ok := handlers[username]
+			if !ok {
+				h = caldav.NewHandler(c)
+				handlers[username] = h
+			}
+
+			h.ServeHTTP(resp, req)
+		}),
+	}
+
+	if s.TLSConfig != nil {
+		log.Println("CalDAV server listening with TLS on", s.Addr)
+		return s.ListenAndServeTLS("", "")
+	}
+
+	log.Println("CalDAV server listening on", s.Addr)
+	return s.ListenAndServe()
+}
+
 func isMbox(br *bufio.Reader) (bool, error) {
 	prefix := []byte("From ")
 	b, err := br.Peek(len(prefix))
@@ -176,6 +223,7 @@ const usage = `usage: hydroxide [options...] <command>
 Commands:
 	auth <username>		Login to ProtonMail via hydroxide
 	carddav			Run hydroxide as a CardDAV server
+	caldav			Run hydroxide as a CalDAV server
 	export-secret-keys <username> Export secret keys
 	imap			Run hydroxide as an IMAP server
 	import-messages <username> [file]	Import messages
@@ -210,6 +258,12 @@ Global options:
 		Disable SMTP for hydroxide serve
 	-disable-carddav
 		Disable CardDAV for hydroxide serve
+	-caldav-host example.com
+		Allowed CalDAV email hostname on which hydroxide listens, defaults to 127.0.0.1
+	-caldav-port example.com
+		CalDAV port on which hydroxide listens, defaults to 8081
+	-disable-caldav
+		Disable CalDAV for hydroxide serve
 	-tls-cert /path/to/cert.pem
 		Path to the certificate to use for incoming connections (Optional)
 	-tls-key /path/to/key.pem
@@ -237,6 +291,10 @@ func main() {
 	carddavHost := flag.String("carddav-host", "127.0.0.1", "Allowed CardDAV email hostname on which hydroxide listens, defaults to 127.0.0.1")
 	carddavPort := flag.String("carddav-port", "8080", "CardDAV port on which hydroxide listens, defaults to 8080")
 	disableCardDAV := flag.Bool("disable-carddav", false, "Disable CardDAV for hydroxide serve")
+
+	caldavHost := flag.String("caldav-host", "127.0.0.1", "Allowed CalDAV email hostname on which hydroxide listens, defaults to 127.0.0.1")
+	caldavPort := flag.String("caldav-port", "8081", "CalDAV port on which hydroxide listens, defaults to 8081")
+	disableCalDAV := flag.Bool("disable-caldav", false, "Disable CalDAV for hydroxide serve")
 
 	tlsCert := flag.String("tls-cert", "", "Path to the certificate to use for incoming connections")
 	tlsCertKey := flag.String("tls-key", "", "Path to the certificate key to use for incoming connections")
@@ -502,15 +560,20 @@ func main() {
 		authManager := auth.NewManager(newClient)
 		eventsManager := events.NewManager()
 		log.Fatal(listenAndServeCardDAV(addr, authManager, eventsManager, tlsConfig))
+	case "caldav":
+		addr := *caldavHost + ":" + *caldavPort
+		authManager := auth.NewManager(newClient)
+		log.Fatal(listenAndServeCalDAV(addr, authManager, tlsConfig))
 	case "serve":
 		smtpAddr := *smtpHost + ":" + *smtpPort
 		imapAddr := *imapHost + ":" + *imapPort
 		carddavAddr := *carddavHost + ":" + *carddavPort
+		caldavAddr := *caldavHost + ":" + *caldavPort
 
 		authManager := auth.NewManager(newClient)
 		eventsManager := events.NewManager()
 
-		done := make(chan error, 3)
+		done := make(chan error, 4)
 		if !*disableSMTP {
 			go func() {
 				done <- listenAndServeSMTP(smtpAddr, debug, authManager, tlsConfig)
@@ -524,6 +587,11 @@ func main() {
 		if !*disableCardDAV {
 			go func() {
 				done <- listenAndServeCardDAV(carddavAddr, authManager, eventsManager, tlsConfig)
+			}()
+		}
+		if !*disableCalDAV {
+			go func() {
+				done <- listenAndServeCalDAV(caldavAddr, authManager, tlsConfig)
 			}()
 		}
 		log.Fatal(<-done)

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.24.0
 require (
 	github.com/ProtonMail/go-crypto v1.4.1
 	github.com/emersion/go-bcrypt v0.0.0-20170822072041-6e724a1baa63
+	github.com/emersion/go-ical v0.0.0-20240127095438-fc1c9d8fb2b6
 	github.com/emersion/go-imap v1.2.1
 	github.com/emersion/go-mbox v1.0.4
 	github.com/emersion/go-message v0.18.2


### PR DESCRIPTION
Fixes #340

## Summary

Adds a CalDAV server that bridges ProtonMail's calendar API to the CalDAV protocol, allowing standard calendar clients (Thunderbird, Apple Calendar, Evolution, etc.) to access ProtonMail calendars.

## Implementation

### New `caldav/` package
- Implements the `go-webdav` CalDAV `Backend` interface
- Fetches calendars and events from ProtonMail's calendar API (`/calendar/v1`)
- Converts ProtonMail calendar events to iCal format
- Caches events in memory (same pattern as CardDAV)

### CLI changes
- New `caldav` command to run standalone CalDAV server
- New flags: `-caldav-host`, `-caldav-port` (default 8081), `-disable-caldav`
- Integrated into `serve` command alongside SMTP, IMAP, and CardDAV

### Usage
```bash
# Standalone CalDAV server
hydroxide caldav

# Run all services
hydroxide serve

# Run all except CalDAV
hydroxide serve -disable-caldav
```

## Dependencies
- `github.com/emersion/go-ical` (already in go.sum from go-webdav)

## Limitations
- Read-only (PutCalendarObject and DeleteCalendarObject return 501)
- Events fetched with ±1 year range
- No recurring event expansion