### PR TITLE
Refresh access token after 2FA to fix key salts 401

### DIFF
--- a/cmd/hydroxide/main.go
+++ b/cmd/hydroxide/main.go
@@ -313,6 +313,15 @@ func main() {
 					log.Fatal(err)
 				}
 				a.Scope = scope
+
+				// After 2FA the pre-2FA access token is rejected by the API; the
+				// /auth/2fa response carries only the elevated scope, not a new token.
+				// Refresh to obtain a usable full-scope token (and a rotated refresh token).
+				newAuth, err := c.AuthRefresh(a)
+				if err != nil {
+					log.Fatal(err)
+				}
+				a = newAuth
 			}
 		}
 

--- a/protonmail/auth.go
+++ b/protonmail/auth.go
@@ -203,6 +203,8 @@ func (c *Client) AuthRefresh(expiredAuth *Auth) (*Auth, error) {
 	auth := respData.auth()
 	//auth.EventID = expiredAuth.EventID
 	auth.PasswordMode = expiredAuth.PasswordMode
+	c.uid = auth.UID
+	c.accessToken = auth.AccessToken
 	return auth, nil
 }
 


### PR DESCRIPTION
## Summary

Accounts with two-factor authentication cannot complete `hydroxide auth`. The SRP login and the TOTP step succeed, but the subsequent `GET /api/keys/salts` returns `[401] Invalid access token`, so the bridge password is never generated. Observed with two-password mode (`PasswordMode 2`).

Fixes #345.

## Cause

After `POST /api/auth/2fa` succeeds, the API returns the elevated scope but no new token (verified with `-debug`: the 2FA response carries only `Scope`, with empty `AccessToken`/`RefreshToken`/`UID`). The access token issued before the 2FA step is no longer accepted, and `cmd/hydroxide` kept using it for `ListKeySalts` and `Unlock`.

## Fix

- `cmd/hydroxide`: after a successful TOTP step, call `AuthRefresh` to obtain a full-scope access token and use the refreshed `Auth` for the remaining login steps. The call is gated on the 2FA branch, so single-factor logins do not exercise it.
- `protonmail`: `AuthRefresh` now updates the client's `uid` and `accessToken`, mirroring `Auth`. Without this the refreshed token would not be used by the state-based requests that follow `AuthTOTP`.

## Testing

Tested on an account with both TOTP 2FA and two-password mode. With `-debug`, the login now issues `POST /api/auth/refresh` after `POST /api/auth/2fa`, `GET /api/keys/salts` returns `Code 1000`, and unlock plus bridge password generation succeed. IMAP works against the resulting session. The change is confined to the 2FA path, so single-factor logins are unaffected.