### PR TITLE
imap: set Sender when creating draft messages

### DIFF
--- a/imap/message.go
+++ b/imap/message.go
@@ -430,6 +430,10 @@ func createMessage(c *protonmail.Client, u *protonmail.User, privateKeys openpgp
 		Subject:   subject,
 		Header:    formatHeader(mr.Header),
 		AddressID: fromAddr.ID,
+		Sender: &protonmail.MessageAddress{
+			Address: fromAddrStr,
+			Name:    fromList[0].Name,
+		},
 	}
 
 	// Create an empty draft


### PR DESCRIPTION
Creating a draft via IMAP APPEND to the Drafts mailbox currently fails with:

    cannot create draft message: [2000] The Sender is required

The Proton API (as of July 2026) requires the `Sender` field on draft creation. `smtp/smtp.go` (SendMail) already populates it, but the IMAP APPEND path (`createMessage` in `imap/message.go`) only sets `AddressID`.

This PR mirrors the SMTP behavior in the IMAP path.

Tested against the live Proton API on 2026-07-13 (free account, hydroxide built from master): APPEND to Drafts fails without this change and succeeds with it.