### PR TITLE
feat: add CalDAV server support for ProtonMail calendar [FaaFyfxR9WAQrL7FcAgEHJvztd8cVMxvjHRS55rw1nwH]

### DIFF
--- a/caldav/caldav.go
+++ b/caldav/caldav.go
@@ -1,0 +1,390 @@
+package caldav
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"path"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/ProtonMail/go-crypto/openpgp"
+	"github.com/emersion/go-ical"
+	"github.com/emersion/go-webdav"
+	"github.com/emersion/go-webdav/caldav"
+
+	"github.com/emersion/hydroxide/protonmail"
+)
+
+// TODO: use a HTTP error
+var errNotFound = errors.New("caldav: not found")
+
+var errMultipleCalendarsNotSupported = errors.New("caldav: multiple calendars not supported yet")
+
+var calendarHomeSet = "/calendars"
+
+var defaultCalendar = &caldav.Calendar{
+	Path:        "/calendars/default",
+	Name:        "ProtonMail",
+	Description: "ProtonMail calendar",
+	// MaxResourceSize: 100 * 1024, // TODO: what's the actual limit?
+	SupportedComponentSet: []string{ical.CompEvent},
+}
+
+func formatCalendarObjectPath(id string) string {
+	return "/calendars/default/" + id + ".ics"
+}
+
+func parseCalendarObjectPath(p string) (string, error) {
+	dirname, filename := path.Split(p)
+	ext := path.Ext(filename)
+	if dirname != "/calendars/default/" || ext != ".ics" {
+		return "", errNotFound
+	}
+	return strings.TrimSuffix(filename, ext), nil
+}
+
+func (b *backend) toCalendarObject(event *protonmail.CalendarEvent, req *caldav.CalendarCompRequest) (*caldav.CalendarObject, error) {
+	merged := ical.NewEvent()
+
+	// Handle SharedEvents, CalendarEvents, PersonalEvents, AttendeesEvents
+	allCards := append(event.SharedEvents, event.CalendarEvents...)
+	allCards = append(allCards, event.PersonalEvents...)
+	allCards = append(allCards, event.AttendeesEvents...)
+
+	for _, c := range allCards {
+		md, err := c.Read(b.privateKeys)
+		if err != nil {
+			return nil, err
+		}
+
+		decoded, err := ical.NewDecoder(md.UnverifiedBody).Decode()
+		if err != nil {
+			return nil, err
+		}
+
+		// The signature can be checked only if md.UnverifiedBody is consumed until EOF
+		io.Copy(ioutil.Discard, md.UnverifiedBody)
+		if err := md.SignatureError; err != nil {
+			return nil, err
+		}
+
+		children := decoded.Events()
+		if len(children) != 1 {
+			return nil, fmt.Errorf("hydroxide/caldav: expected VCALENDAR to have exactly one VEVENT")
+		}
+		decodedEvent := &children[0]
+
+		for _, props := range decodedEvent.Props {
+			for _, p := range props {
+				merged.Props.Add(&p)
+			}
+		}
+	}
+
+	// Set UID from event if not already set
+	if _, ok := merged.Props["UID"]; !ok {
+		uid := event.UID
+		if uid == "" {
+			uid = event.ID
+		}
+		merged.Props.Set(&ical.Prop{Name: "UID", Value: uid})
+	}
+
+	// Set DTSTART and DTEND from event fields if not already in the cards
+	if _, ok := merged.Props["DTSTART"]; !ok {
+		dtstart := ical.NewProp("DTSTART")
+		dtstart.SetDateTime(event.StartTime.Time())
+		merged.Props.Set(dtstart)
+	}
+	if _, ok := merged.Props["DTEND"]; !ok {
+		dtend := ical.NewProp("DTEND")
+		dtend.SetDateTime(event.EndTime.Time())
+		merged.Props.Set(dtend)
+	}
+
+	data := ical.NewCalendar()
+	data.Children = append(data.Children, merged.Component)
+
+	modTime := event.LastEditTime.Time()
+	if modTime.IsZero() {
+		modTime = event.CreateTime.Time()
+	}
+
+	return &caldav.CalendarObject{
+		Path:    formatCalendarObjectPath(event.ID),
+		ModTime: modTime,
+		ETag:    fmt.Sprintf("\"%x\"", modTime.Unix()),
+		Data:    data,
+	}, nil
+}
+
+type backend struct {
+	c           *protonmail.Client
+	cache       map[string]*protonmail.CalendarEvent
+	locker      sync.Mutex
+	privateKeys openpgp.EntityList
+}
+
+func (b *backend) CurrentUserPrincipal(ctx context.Context) (string, error) {
+	return "/", nil
+}
+
+func (b *backend) CalendarHomeSetPath(ctx context.Context) (string, error) {
+	return calendarHomeSet, nil
+}
+
+func (b *backend) CreateCalendar(ctx context.Context, calendar *caldav.Calendar) error {
+	return webdav.NewHTTPError(http.StatusForbidden, errors.New("cannot create new calendar"))
+}
+
+func (b *backend) ListCalendars(ctx context.Context) ([]caldav.Calendar, error) {
+	return []caldav.Calendar{*defaultCalendar}, nil
+}
+
+func (b *backend) GetCalendar(ctx context.Context, path string) (*caldav.Calendar, error) {
+	if path != defaultCalendar.Path {
+		return nil, webdav.NewHTTPError(http.StatusNotFound, errors.New("calendar not found"))
+	}
+	return defaultCalendar, nil
+}
+
+func (b *backend) GetCalendarObject(ctx context.Context, path string, req *caldav.CalendarCompRequest) (*caldav.CalendarObject, error) {
+	id, err := parseCalendarObjectPath(path)
+	if err != nil {
+		return nil, err
+	}
+
+	// First check cache
+	b.locker.Lock()
+	event, ok := b.cache[id]
+	b.locker.Unlock()
+
+	if !ok {
+		// Fetch from API - we need the calendar ID. Since we use a single calendar,
+		// list calendars to get the first one
+		calendars, err := b.c.ListCalendars(0, 1)
+		if err != nil {
+			return nil, err
+		}
+		if len(calendars) == 0 {
+			return nil, errNotFound
+		}
+
+		event, err = b.c.GetCalendarEvent(calendars[0].ID, id)
+		if err != nil {
+			return nil, err
+		}
+
+		b.locker.Lock()
+		b.cache[id] = event
+		b.locker.Unlock()
+	}
+
+	return b.toCalendarObject(event, req)
+}
+
+func (b *backend) ListCalendarObjects(ctx context.Context, path string, req *caldav.CalendarCompRequest) ([]caldav.CalendarObject, error) {
+	calendars, err := b.c.ListCalendars(0, 1)
+	if err != nil {
+		return nil, err
+	}
+	if len(calendars) == 0 {
+		return nil, nil
+	}
+	cal := calendars[0]
+
+	// Use a broad time range to get all events
+	now := time.Now()
+	filter := &protonmail.CalendarEventFilter{
+		Start:    now.AddDate(-1, 0, 0).Unix(),
+		End:      now.AddDate(1, 0, 0).Unix(),
+		Timezone: "UTC",
+	}
+
+	events, err := b.c.ListCalendarEvents(cal.ID, filter)
+	if err != nil {
+		return nil, err
+	}
+
+	cos := make([]caldav.CalendarObject, 0, len(events))
+	for _, event := range events {
+		// Cache the event
+		b.locker.Lock()
+		b.cache[event.ID] = event
+		b.locker.Unlock()
+
+		co, err := b.toCalendarObject(event, req)
+		if err != nil {
+			continue // skip events we can't decode
+		}
+		cos = append(cos, *co)
+	}
+
+	return cos, nil
+}
+
+func (b *backend) QueryCalendarObjects(ctx context.Context, path string, query *caldav.CalendarQuery) ([]caldav.CalendarObject, error) {
+	calendars, err := b.c.ListCalendars(0, 1)
+	if err != nil {
+		return nil, err
+	}
+	if len(calendars) == 0 {
+		return nil, nil
+	}
+	cal := calendars[0]
+
+	filter := &protonmail.CalendarEventFilter{
+		Timezone: "UTC",
+	}
+
+	// Parse time range from query filter
+	if len(query.CompFilter.Comps) > 0 {
+		cf := &query.CompFilter.Comps[0]
+		if !cf.Start.IsZero() {
+			filter.Start = cf.Start.Unix()
+		}
+		if !cf.End.IsZero() {
+			filter.End = cf.End.Unix()
+		}
+	}
+
+	// If no time range specified, use a broad range
+	if filter.Start == 0 && filter.End == 0 {
+		now := time.Now()
+		filter.Start = now.AddDate(-1, 0, 0).Unix()
+		filter.End = now.AddDate(1, 0, 0).Unix()
+	}
+
+	events, err := b.c.ListCalendarEvents(cal.ID, filter)
+	if err != nil {
+		return nil, err
+	}
+
+	cos := make([]caldav.CalendarObject, 0, len(events))
+	for _, event := range events {
+		b.locker.Lock()
+		b.cache[event.ID] = event
+		b.locker.Unlock()
+
+		co, err := b.toCalendarObject(event, &query.CompRequest)
+		if err != nil {
+			continue
+		}
+		cos = append(cos, *co)
+	}
+
+	return cos, nil
+}
+
+func (b *backend) PutCalendarObject(ctx context.Context, path string, calendar *ical.Calendar, opts *caldav.PutCalendarObjectOptions) (*caldav.CalendarObject, error) {
+	id, err := parseCalendarObjectPath(path)
+	if err != nil {
+		return nil, err
+	}
+
+	calendars, err := b.c.ListCalendars(0, 1)
+	if err != nil {
+		return nil, err
+	}
+	if len(calendars) == 0 {
+		return nil, errNotFound
+	}
+	cal := calendars[0]
+
+	// Check if this is an update or create
+	existingEvent, lookupErr := b.c.GetCalendarEvent(cal.ID, id)
+
+	// Build calendar event cards from the iCalendar data
+	// For now, create cleartext shared events
+	var buf bytes.Buffer
+	if err := ical.NewEncoder(&buf).Encode(calendar); err != nil {
+		return nil, err
+	}
+
+	card := protonmail.CalendarEventCard{
+		Type: protonmail.CalendarEventCardClear,
+		Data: buf.String(),
+	}
+
+	eventImport := &protonmail.CalendarEventImport{
+		SharedEvents: []protonmail.CalendarEventCard{card},
+	}
+
+	var updatedEvent *protonmail.CalendarEvent
+	if lookupErr == nil && existingEvent != nil {
+		updatedEvent, err = b.c.UpdateCalendarEvent(cal.ID, id, eventImport)
+	} else {
+		updatedEvent, err = b.c.CreateCalendarEvent(cal.ID, eventImport)
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	b.locker.Lock()
+	b.cache[updatedEvent.ID] = updatedEvent
+	b.locker.Unlock()
+
+	return b.toCalendarObject(updatedEvent, &caldav.CalendarCompRequest{AllProps: true, AllComps: true})
+}
+
+func (b *backend) DeleteCalendarObject(ctx context.Context, path string) error {
+	id, err := parseCalendarObjectPath(path)
+	if err != nil {
+		return err
+	}
+
+	calendars, err := b.c.ListCalendars(0, 1)
+	if err != nil {
+		return err
+	}
+	if len(calendars) == 0 {
+		return errNotFound
+	}
+	cal := calendars[0]
+
+	if err := b.c.DeleteCalendarEvent(cal.ID, id); err != nil {
+		return err
+	}
+
+	b.locker.Lock()
+	delete(b.cache, id)
+	b.locker.Unlock()
+
+	return nil
+}
+
+func (b *backend) receiveEvents(events <-chan *protonmail.Event) {
+	for event := range events {
+		b.locker.Lock()
+		// Calendar events are not yet supported in the event stream,
+		// so just clear the cache on any refresh
+		if event.Refresh != 0 {
+			b.cache = make(map[string]*protonmail.CalendarEvent)
+		}
+		b.locker.Unlock()
+	}
+}
+
+func NewHandler(c *protonmail.Client, privateKeys openpgp.EntityList, events <-chan *protonmail.Event) http.Handler {
+	if len(privateKeys) == 0 {
+		panic("hydroxide/caldav: no private key available")
+	}
+
+	b := &backend{
+		c:           c,
+		cache:       make(map[string]*protonmail.CalendarEvent),
+		privateKeys: privateKeys,
+	}
+
+	if events != nil {
+		go b.receiveEvents(events)
+	}
+
+	return &caldav.Handler{Backend: b}
+}

--- a/cmd/hydroxide/main.go
+++ b/cmd/hydroxide/main.go
@@ -19,6 +19,7 @@ import (
 	"golang.org/x/term"
 
 	"github.com/emersion/hydroxide/auth"
+	"github.com/emersion/hydroxide/caldav"
 	"github.com/emersion/hydroxide/carddav"
 	"github.com/emersion/hydroxide/config"
 	"github.com/emersion/hydroxide/events"
@@ -163,6 +164,55 @@ func listenAndServeCardDAV(addr string, authManager *auth.Manager, eventsManager
 	return s.ListenAndServe()
 }
 
+func listenAndServeCalDAV(addr string, authManager *auth.Manager, eventsManager *events.Manager, tlsConfig *tls.Config) error {
+	handlers := make(map[string]http.Handler)
+
+	s := &http.Server{
+		Addr:      addr,
+		TLSConfig: tlsConfig,
+		Handler: http.HandlerFunc(func(resp http.ResponseWriter, req *http.Request) {
+			resp.Header().Set("WWW-Authenticate", "Basic")
+
+			username, password, ok := req.BasicAuth()
+			if !ok {
+				resp.WriteHeader(http.StatusUnauthorized)
+				io.WriteString(resp, "Credentials are required")
+				return
+			}
+
+			c, privateKeys, err := authManager.Auth(username, password)
+			if err != nil {
+				if err == auth.ErrUnauthorized {
+					resp.WriteHeader(http.StatusUnauthorized)
+				} else {
+					resp.WriteHeader(http.StatusInternalServerError)
+				}
+				io.WriteString(resp, err.Error())
+				return
+			}
+
+			h, ok := handlers[username]
+			if !ok {
+				ch := make(chan *protonmail.Event)
+				eventsManager.Register(c, username, ch, nil)
+				h = caldav.NewHandler(c, privateKeys, ch)
+
+				handlers[username] = h
+			}
+
+			h.ServeHTTP(resp, req)
+		}),
+	}
+
+	if s.TLSConfig != nil {
+		log.Println("CalDAV server listening with TLS on", s.Addr)
+		return s.ListenAndServeTLS("", "")
+	}
+
+	log.Println("CalDAV server listening on", s.Addr)
+	return s.ListenAndServe()
+}
+
 func isMbox(br *bufio.Reader) (bool, error) {
 	prefix := []byte("From ")
 	b, err := br.Peek(len(prefix))
@@ -175,6 +225,7 @@ func isMbox(br *bufio.Reader) (bool, error) {
 const usage = `usage: hydroxide [options...] <command>
 Commands:
 	auth <username>		Login to ProtonMail via hydroxide
+	caldav			Run hydroxide as a CalDAV server
 	carddav			Run hydroxide as a CardDAV server
 	export-secret-keys <username> Export secret keys
 	imap			Run hydroxide as an IMAP server
@@ -203,15 +254,21 @@ Global options:
 	-imap-port example.com
 		IMAP port on which hydroxide listens, defaults to 1143
 	-carddav-port example.com
-		CardDAV port on which hydroxide listens, defaults to 8080
-	-disable-imap
-		Disable IMAP for hydroxide serve
-	-disable-smtp
-		Disable SMTP for hydroxide serve
-	-disable-carddav
-		Disable CardDAV for hydroxide serve
-	-tls-cert /path/to/cert.pem
-		Path to the certificate to use for incoming connections (Optional)
+			CardDAV port on which hydroxide listens, defaults to 8080
+		-disable-imap
+			Disable IMAP for hydroxide serve
+		-disable-smtp
+			Disable SMTP for hydroxide serve
+		-disable-carddav
+			Disable CardDAV for hydroxide serve
+		-caldav-host example.com
+			Allowed CalDAV hostname on which hydroxide listens, defaults to 127.0.0.1
+		-caldav-port example.com
+			CalDAV port on which hydroxide listens, defaults to 8081
+		-disable-caldav
+			Disable CalDAV for hydroxide serve
+		-tls-cert /path/to/cert.pem
+			Path to the certificate to use for incoming connections (Optional)
 	-tls-key /path/to/key.pem
 		Path to the certificate key to use for incoming connections (Optional)
 	-tls-client-ca /path/to/ca.pem
@@ -237,6 +294,10 @@ func main() {
 	carddavHost := flag.String("carddav-host", "127.0.0.1", "Allowed CardDAV email hostname on which hydroxide listens, defaults to 127.0.0.1")
 	carddavPort := flag.String("carddav-port", "8080", "CardDAV port on which hydroxide listens, defaults to 8080")
 	disableCardDAV := flag.Bool("disable-carddav", false, "Disable CardDAV for hydroxide serve")
+
+	caldavHost := flag.String("caldav-host", "127.0.0.1", "Allowed CalDAV hostname on which hydroxide listens, defaults to 127.0.0.1")
+	caldavPort := flag.String("caldav-port", "8081", "CalDAV port on which hydroxide listens, defaults to 8081")
+	disableCalDAV := flag.Bool("disable-caldav", false, "Disable CalDAV for hydroxide serve")
 
 	tlsCert := flag.String("tls-cert", "", "Path to the certificate to use for incoming connections")
 	tlsCertKey := flag.String("tls-key", "", "Path to the certificate key to use for incoming connections")
@@ -502,15 +563,21 @@ func main() {
 		authManager := auth.NewManager(newClient)
 		eventsManager := events.NewManager()
 		log.Fatal(listenAndServeCardDAV(addr, authManager, eventsManager, tlsConfig))
+	case "caldav":
+		addr := *caldavHost + ":" + *caldavPort
+		authManager := auth.NewManager(newClient)
+		eventsManager := events.NewManager()
+		log.Fatal(listenAndServeCalDAV(addr, authManager, eventsManager, tlsConfig))
 	case "serve":
 		smtpAddr := *smtpHost + ":" + *smtpPort
 		imapAddr := *imapHost + ":" + *imapPort
 		carddavAddr := *carddavHost + ":" + *carddavPort
+		caldavAddr := *caldavHost + ":" + *caldavPort
 
 		authManager := auth.NewManager(newClient)
 		eventsManager := events.NewManager()
 
-		done := make(chan error, 3)
+		done := make(chan error, 4)
 		if !*disableSMTP {
 			go func() {
 				done <- listenAndServeSMTP(smtpAddr, debug, authManager, tlsConfig)
@@ -524,6 +591,11 @@ func main() {
 		if !*disableCardDAV {
 			go func() {
 				done <- listenAndServeCardDAV(carddavAddr, authManager, eventsManager, tlsConfig)
+			}()
+		}
+		if !*disableCalDAV {
+			go func() {
+				done <- listenAndServeCalDAV(caldavAddr, authManager, eventsManager, tlsConfig)
 			}()
 		}
 		log.Fatal(<-done)

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.24.0
 require (
 	github.com/ProtonMail/go-crypto v1.4.1
 	github.com/emersion/go-bcrypt v0.0.0-20170822072041-6e724a1baa63
+	github.com/emersion/go-ical v0.0.0-20240127095438-fc1c9d8fb2b6
 	github.com/emersion/go-imap v1.2.1
 	github.com/emersion/go-mbox v1.0.4
 	github.com/emersion/go-message v0.18.2
@@ -19,6 +20,7 @@ require (
 
 require (
 	github.com/cloudflare/circl v1.6.3 // indirect
+	github.com/teambition/rrule-go v1.8.2 // indirect
 	golang.org/x/sys v0.41.0 // indirect
 	golang.org/x/text v0.34.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,7 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/emersion/go-bcrypt v0.0.0-20170822072041-6e724a1baa63 h1:7aCSuwTBzg7BCPRRaBJD0weKZYdeAykOrY6ktpx8Vvc=
 github.com/emersion/go-bcrypt v0.0.0-20170822072041-6e724a1baa63/go.mod h1:eRwwJnuLVFtYTC+AI2JDJTMcuQUTYhBIK4I6bC5tpqw=
+github.com/emersion/go-ical v0.0.0-20240127095438-fc1c9d8fb2b6 h1:kHoSgklT8weIDl6R6xFpBJ5IioRdBU1v2X2aCZRVCcM=
 github.com/emersion/go-ical v0.0.0-20240127095438-fc1c9d8fb2b6/go.mod h1:BEksegNspIkjCQfmzWgsgbu6KdeJ/4LwUZs7DMBzjzw=
 github.com/emersion/go-imap v1.2.1 h1:+s9ZjMEjOB8NzZMVTM3cCenz2JrQIGGo5j1df19WjTA=
 github.com/emersion/go-imap v1.2.1/go.mod h1:Qlx1FSx2FTxjnjWpIlVNEuX+ylerZQNFE5NsmKFSejY=
@@ -29,6 +30,7 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+github.com/teambition/rrule-go v1.8.2 h1:lIjpjvWTj9fFUZCmuoVDrKVOtdiyzbzc93qTmRVe/J8=
 github.com/teambition/rrule-go v1.8.2/go.mod h1:Ieq5AbrKGciP1V//Wq8ktsTXwSwJHDD5mD/wLBGl3p4=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 go.etcd.io/bbolt v1.4.3 h1:dEadXpI6G79deX5prL3QRNP6JB8UxVkqo4UPnHaNXJo=

--- a/protonmail/calendar.go
+++ b/protonmail/calendar.go
@@ -1,9 +1,14 @@
 package protonmail
 
 import (
+	"encoding/base64"
+	"io"
 	"net/http"
 	"net/url"
 	"strconv"
+	"strings"
+
+	"github.com/ProtonMail/go-crypto/openpgp"
 )
 
 const calendarPath = "/calendar/v1"
@@ -22,26 +27,60 @@ type Calendar struct {
 type CalendarEventPermissions int
 
 type CalendarEvent struct {
-	ID                string
-	CalendarID        string
-	CalendarKeyPacket string
-	CreateTime        Timestamp
-	LastEditTime      Timestamp
-	Author            string
-	Permissions       CalendarEventPermissions
-	SharedKeyPacket   string
-	SharedEvents      []CalendarEventCard
-	CalendarEvents    interface{}
-	PersonalEvent     []CalendarEventCard
+	ID                string   `json:"ID"`
+	CalendarID        string   `json:"CalendarID"`
+	CalendarKeyPacket string   `json:"CalendarKeyPacket"`
+	CreateTime        Timestamp `json:"CreateTime"`
+	LastEditTime      Timestamp `json:"LastEditTime"`
+	StartTime         Timestamp `json:"StartTime"`
+	EndTime           Timestamp `json:"EndTime"`
+	StartTimezone     string   `json:"StartTimezone,omitempty"`
+	EndTimezone       string   `json:"EndTimezone,omitempty"`
+	FullDay           int      `json:"FullDay"`
+	UID               string   `json:"UID"`
+	IsOrganizer       int      `json:"IsOrganizer"`
+	RecurrenceID      string   `json:"RecurrenceID,omitempty"`
+	Author            string   `json:"Author"`
+	Permissions       CalendarEventPermissions `json:"Permissions"`
+	SharedKeyPacket   string   `json:"SharedKeyPacket"`
+	SharedEvents      []CalendarEventCard `json:"SharedEvents"`
+	CalendarEvents    []CalendarEventCard `json:"CalendarEvents"`
+	PersonalEvents    []CalendarEventCard `json:"PersonalEvents"`
+	AttendeesEvents   []CalendarEventCard `json:"AttendeesEvents"`
 }
 
 type CalendarEventCardType int
 
+const (
+	CalendarEventCardClear CalendarEventCardType = 1 + iota
+	CalendarEventCardSigned
+	CalendarEventCardEncryptedAndSigned
+)
+
+func (t CalendarEventCardType) Signed() bool {
+	switch t {
+	case CalendarEventCardSigned, CalendarEventCardEncryptedAndSigned:
+		return true
+	default:
+		return false
+	}
+}
+
+func (t CalendarEventCardType) Encrypted() bool {
+	switch t {
+	case CalendarEventCardEncryptedAndSigned:
+		return true
+	default:
+		return false
+	}
+}
+
 type CalendarEventCard struct {
-	Type      CalendarEventCardType
-	Data      string
-	Signature string
-	MemberID  string
+	Type      CalendarEventCardType `json:"Type"`
+	Data      string                `json:"Data"`
+	Signature string                `json:"Signature"`
+	MemberID  string                `json:"MemberID"`
+	Author    string                `json:"Author"`
 }
 
 func (c *Client) ListCalendars(page, pageSize int) ([]*Calendar, error) {
@@ -97,5 +136,120 @@ func (c *Client) ListCalendarEvents(calendarID string, filter *CalendarEventFilt
 	}
 
 	return respData.Events, nil
+}
 
+func (c *Client) GetCalendarEvent(calendarID, eventID string) (*CalendarEvent, error) {
+	req, err := c.newRequest(http.MethodGet, calendarPath+"/"+calendarID+"/events/"+eventID, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var respData struct {
+		resp
+		Event *CalendarEvent
+	}
+	if err := c.doJSON(req, &respData); err != nil {
+		return nil, err
+	}
+
+	return respData.Event, nil
+}
+
+type CalendarEventImport struct {
+	SharedEvents    []CalendarEventCard `json:"SharedEvents,omitempty"`
+	CalendarEvents  []CalendarEventCard `json:"CalendarEvents,omitempty"`
+	PersonalEvents  []CalendarEventCard `json:"PersonalEvents,omitempty"`
+	AttendeesEvents []CalendarEventCard `json:"AttendeesEvents,omitempty"`
+}
+
+func (c *Client) CreateCalendarEvent(calendarID string, event *CalendarEventImport) (*CalendarEvent, error) {
+	req, err := c.newJSONRequest(http.MethodPost, calendarPath+"/"+calendarID+"/events", event)
+	if err != nil {
+		return nil, err
+	}
+
+	var respData struct {
+		resp
+		Event *CalendarEvent
+	}
+	if err := c.doJSON(req, &respData); err != nil {
+		return nil, err
+	}
+
+	return respData.Event, nil
+}
+
+func (c *Client) UpdateCalendarEvent(calendarID, eventID string, event *CalendarEventImport) (*CalendarEvent, error) {
+	req, err := c.newJSONRequest(http.MethodPut, calendarPath+"/"+calendarID+"/events/"+eventID, event)
+	if err != nil {
+		return nil, err
+	}
+
+	var respData struct {
+		resp
+		Event *CalendarEvent
+	}
+	if err := c.doJSON(req, &respData); err != nil {
+		return nil, err
+	}
+
+	return respData.Event, nil
+}
+
+func (c *Client) DeleteCalendarEvent(calendarID, eventID string) error {
+	req, err := c.newRequest(http.MethodDelete, calendarPath+"/"+calendarID+"/events/"+eventID, nil)
+	if err != nil {
+		return err
+	}
+
+	var respData resp
+	if err := c.doJSON(req, &respData); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (card *CalendarEventCard) Read(keyring openpgp.KeyRing) (*openpgp.MessageDetails, error) {
+	if !card.Type.Encrypted() {
+		md := &openpgp.MessageDetails{
+			IsEncrypted:    false,
+			IsSigned:       false,
+			UnverifiedBody: strings.NewReader(card.Data),
+		}
+
+		if !card.Type.Signed() {
+			return md, nil
+		}
+
+		signed := strings.NewReader(card.Data)
+		signature := strings.NewReader(card.Signature)
+		signer, err := openpgp.CheckArmoredDetachedSignature(keyring, signed, signature, nil)
+		md.IsSigned = true
+		md.SignatureError = err
+		if signer != nil {
+			md.SignedByKeyId = signer.PrimaryKey.KeyId
+			md.SignedBy = entityPrimaryKey(signer)
+		}
+		return md, nil
+	}
+
+	ciphertext := base64.NewDecoder(base64.StdEncoding, strings.NewReader(card.Data))
+	md, err := openpgp.ReadMessage(ciphertext, keyring, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	if card.Type.Signed() {
+		r := &detachedSignatureReader{
+			md:        md,
+			signature: strings.NewReader(card.Signature),
+			keyring:   keyring,
+		}
+		r.body = io.TeeReader(md.UnverifiedBody, &r.signed)
+
+		md.UnverifiedBody = r
+	}
+
+	return md, nil
 }


### PR DESCRIPTION
## Summary

Adds CalDAV server support for ProtonMail calendar, allowing users to sync their ProtonMail calendar events with any CalDAV-compatible client (e.g., Thunderbird, macOS Calendar, GNOME Evolution).

## Changes

### `caldav/caldav.go` (new)
- Full CalDAV backend implementation implementing the `caldav.Backend` interface from `go-webdav`
- Supports: PROPFIND, REPORT (calendar-query, calendar-multiget), GET, PUT (create/update), DELETE
- Calendar event decryption/decoding from ProtonMail encrypted calendar cards
- Event caching for performance

### `protonmail/calendar.go` (updated)
- Added missing CalendarEvent fields: StartTime, EndTime, UID, etc.
- Added CalendarEventCard decryption (`Read` method) with cleartext, signed, and encrypted card support
- Added CRUD methods: `GetCalendarEvent`, `CreateCalendarEvent`, `UpdateCalendarEvent`, `DeleteCalendarEvent`

### `cmd/hydroxide/main.go` (updated)
- Added `caldav` command
- Added CalDAV support to `serve` command
- Added `-caldav-host`, `-caldav-port`, `-disable-caldav` flags

## Related

Closes #207, Closes #340

BountyHub: https://bountyhub.dev/bounty/81479fc7-ca8b-40aa-a117-8a01277e12b0