### PR TITLE
fix(protonmail): bump `defaultAppVersion` to solve CAPTCHA

### DIFF
--- a/cmd/hydroxide/main.go
+++ b/cmd/hydroxide/main.go
@@ -31,7 +31,7 @@ import (
 
 const (
 	defaultAPIEndpoint = "https://mail.proton.me/api"
-	defaultAppVersion  = "Other"
+	defaultAppVersion  = "web-mail@5.0.124.7"
 )
 
 var (


### PR DESCRIPTION
`x-pm-appversion` being "Other" (and absence) triggers anti-bot.
Solution: Use the exact ID from the webapp. Login works now.

This PR simply changes the default constant, as the code is correct. And
sice there's the flag `-app-version`, this new string can be used in
builds without this change also, see below.

State before fix (known bug):
```
$ hydroxide auth thisago
Password:
2026/07/28 22:18:09 request failed: POST https://mail.proton.me/api/auth: [9001] For security reasons, please complete CAPTCHA. If you can't pass it, please try updating your app or contact us here: https://proton.me/support/appeal-abuse
2026/07/28 22:18:09 [9001] For security reasons, please complete CAPTCHA. If you can't pass it, please try updating your app or contact us here: https://proton.me/support/appeal-abuse
```

With the custom `-app-version`, before this bump):
```
$ guix shell hydroxide -- hydroxide -app-version 'web-mail@5.0.124.7' auth thisago
Password:
2FA TOTP code: ...
Bridge password: ...
```

After this fix:
```
$ ~/go/bin/hydroxide auth thisago
Password:
2FA TOTP code: ...
Bridge password: ...
```

Closes: #235; Closes #328
